### PR TITLE
#104 Implement autofill feature for password fields.

### DIFF
--- a/contenido/classes/html/class.html.formelement.php
+++ b/contenido/classes/html/class.html.formelement.php
@@ -37,7 +37,7 @@ class cHTMLFormElement extends cHTML {
      *         Item disabled flag (non-empty to set disabled)
      * @param int|null $tabindex [optional]
      *         Tab index for form elements
-     * @param string $accesskey [optional]
+     * @param string $accessKey [optional]
      *         Key to access the field
      * @param string $class [optional]
      *         CSS class name to set
@@ -47,14 +47,14 @@ class cHTMLFormElement extends cHTML {
         $id = '',
         $disabled = false,
         $tabindex = null,
-        $accesskey = '',
+        $accessKey = '',
         $class = 'text_medium'
     ) {
         $this->_tag = 'input';
         parent::__construct(['name' => $name, 'id' => $id, 'class' => $class]);
         $this->setDisabled($disabled);
         $this->setTabindex($tabindex);
-        $this->setAccessKey($accesskey);
+        $this->setAccessKey($accessKey);
     }
 
     /**
@@ -113,14 +113,14 @@ class cHTMLFormElement extends cHTML {
     /**
      * Sets the access key for this element.
      *
-     * @param string $accesskey
+     * @param string $accessKey
      *         The length of the access key. May be A-Z and 0-9.
      * @return cHTMLFormElement
      *         $this for chaining
      */
-    public function setAccessKey($accesskey) {
-        if ((cString::getStringLength($accesskey) == 1) && cString::isAlphanumeric($accesskey)) {
-            $this->updateAttribute('accesskey', $accesskey);
+    public function setAccessKey($accessKey) {
+        if ((cString::getStringLength($accessKey) == 1) && cString::isAlphanumeric($accessKey)) {
+            $this->updateAttribute('accesskey', $accessKey);
         } else {
             $this->removeAttribute('accesskey');
         }

--- a/contenido/classes/html/class.html.passwordbox.php
+++ b/contenido/classes/html/class.html.passwordbox.php
@@ -33,7 +33,7 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      *
      * @param string $name
      *         Name of the element
-     * @param string $initvalue [optional]
+     * @param string $value [optional]
      *         Initial value of the box
      * @param int $width [optional]
      *         width of the text box
@@ -45,20 +45,31 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      *         Item disabled flag (non-empty to set disabled)
      * @param int|null $tabindex [optional]
      *         Tab index for form elements
-     * @param string $accesskey [optional]
+     * @param string $accessKey [optional]
      *         Key to access the field
      * @param string $class [optional]
      *         the class of this element
      */
-    public function __construct($name, $initvalue = '', $width = '', $maxlength = '', $id = '', $disabled = false, $tabindex = null, $accesskey = '', $class = '') {
-        parent::__construct($name, $id, $disabled, $tabindex, $accesskey, $class);
+    public function __construct($name, $value = '', $width = 0, $maxlength = 0, $id = '', $disabled = false, $tabindex = null, $accessKey = '', $class = '') {
+        parent::__construct($name, $id, $disabled, $tabindex, $accessKey, $class);
         $this->_tag = 'input';
-        $this->setValue($initvalue);
+        $this->setValue($value);
 
         $this->setWidth($width);
         $this->setMaxLength($maxlength);
 
         $this->updateAttribute('type', 'password');
+    }
+
+    /**
+     * Sets the autocomplete attribute of the element.
+     *
+     * @param string $value - The autocomplete attribute value
+     * @return cHTMLPasswordbox|cHTML
+     */
+    public function setAutocomplete($value) {
+        $value = cString::toLowerCase(cSecurity::toString($value));
+        return $this->updateAttribute('autocomplete', $value);
     }
 
     /**
@@ -70,7 +81,7 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      *         $this for chaining
      */
     public function setWidth($width) {
-        $width = intval($width);
+        $width = cSecurity::toInteger($width);
 
         if ($width <= 0) {
             $width = 20;
@@ -82,18 +93,18 @@ class cHTMLPasswordbox extends cHTMLFormElement {
     /**
      * Sets the maximum input length of the text box.
      *
-     * @param int $maxlen
+     * @param int $maxLength
      *         maximum input length
      * @return cHTMLPasswordbox
      *         $this for chaining
      */
-    public function setMaxLength($maxlen) {
-        $maxlen = intval($maxlen);
+    public function setMaxLength($maxLength) {
+        $maxLength = cSecurity::toInteger($maxLength);
 
-        if ($maxlen <= 0) {
+        if ($maxLength <= 0) {
             return $this->removeAttribute('maxlength');
         } else {
-            return $this->updateAttribute('maxlength', $maxlen);
+            return $this->updateAttribute('maxlength', $maxLength);
         }
     }
 
@@ -107,6 +118,56 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      */
     public function setValue($value) {
         return $this->updateAttribute('value', $value);
+    }
+
+    /**
+     * Generates the HTML markup for the input field of type password.
+     * Additionally, it deals with the attribute "autocomplete" set to "off".
+     * This should work as expected but some browser or password manager may
+     * still pre fill the field with the previous stored value.
+     * Setting the field initially to readonly and enabling it again after
+     * getting focus does the trick!
+     *
+     * @TODO This function could be moved to somewhere else, because ll input, textarea,
+     *       select and form elements could use the autocomplete attribute.
+     *       But, only input and textarea can have readonly attribute.
+     *
+     *
+     * @return string
+     */
+    public function toHtml() {
+        $sReadonly = $this->getAttribute('readonly') !== null;
+        $autocomplete = $this->getAttribute('autocomplete');
+
+        if ($autocomplete !== 'off' || $sReadonly) {
+            // Field has no autocomplete="off" or has already readonly attribute, nothing to do here...
+            return parent::toHtml();
+        }
+
+        // Handle autocomplete="off", disable the field and enable it again via JavaScript!
+
+        if (!$this->getAttribute('id')) {
+            $this->advanceID();
+        }
+        $this->setAttribute('readonly', 'readonly');
+
+        $html = parent::toHtml();
+        // NOTE: If you change the code below, don't forget to adapt the unit test
+        //       cHtmlPasswordBoxTest->testAutocomplete()!
+        $html .= '
+    <script type="text/javascript">
+        (function(Con, $) {
+            $(function() {
+                // Remove readonly attribute on focus
+                $("#' . $this->getID() . '").on("focus", function() {
+                    $(this).prop("readonly", false);
+                });
+            });
+        })(Con, Con.$);
+    </script>
+        ';
+
+        return $html;
     }
 
 }

--- a/contenido/classes/html/class.html.passwordbox.php
+++ b/contenido/classes/html/class.html.passwordbox.php
@@ -24,6 +24,11 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
 class cHTMLPasswordbox extends cHTMLFormElement {
 
     /**
+     * @var bool $_autofill
+     */
+    protected $_autofill = true;
+
+    /**
      * Constructor to create an instance of this class.
      *
      * Creates an HTML password box.
@@ -62,14 +67,14 @@ class cHTMLPasswordbox extends cHTMLFormElement {
     }
 
     /**
-     * Sets the autocomplete attribute of the element.
+     * Sets the autofill property of the element.
      *
-     * @param string $value - The autocomplete attribute value
+     * @param boolean $autofill - The autofill flag
      * @return cHTMLPasswordbox|cHTML
      */
-    public function setAutocomplete($value) {
-        $value = cString::toLowerCase(cSecurity::toString($value));
-        return $this->updateAttribute('autocomplete', $value);
+    public function setAutofill($autofill) {
+        $this->_autofill = cSecurity::toBoolean($autofill);
+        return $this;
     }
 
     /**
@@ -122,9 +127,10 @@ class cHTMLPasswordbox extends cHTMLFormElement {
 
     /**
      * Generates the HTML markup for the input field of type password.
-     * Additionally, it deals with the attribute "autocomplete" set to "off".
-     * This should work as expected but some browser or password manager may
-     * still pre fill the field with the previous stored value.
+     * Additionally, it deals with the enabled status of th property $_autofill.
+     * Setting the autocomplete to "off" will prevent from autocompletion but
+     * some browser or password manager may autofill the field with the
+     * previous stored value, which is not always wanted.
      * Setting the field initially to readonly and enabling it again after
      * getting focus does the trick!
      *
@@ -137,10 +143,9 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      */
     public function toHtml() {
         $sReadonly = $this->getAttribute('readonly') !== null;
-        $autocomplete = $this->getAttribute('autocomplete');
 
-        if ($autocomplete !== 'off' || $sReadonly) {
-            // Field has no autocomplete="off" or has already readonly attribute, nothing to do here...
+        if ($this->_autofill === true || $sReadonly) {
+            // Field can be filled or has already readonly attribute, nothing to do here...
             return parent::toHtml();
         }
 

--- a/contenido/classes/html/class.html.passwordbox.php
+++ b/contenido/classes/html/class.html.passwordbox.php
@@ -128,7 +128,7 @@ class cHTMLPasswordbox extends cHTMLFormElement {
      * Setting the field initially to readonly and enabling it again after
      * getting focus does the trick!
      *
-     * @TODO This function could be moved to somewhere else, because ll input, textarea,
+     * @TODO This function could be moved to somewhere else, because all input, textarea,
      *       select and form elements could use the autocomplete attribute.
      *       But, only input and textarea can have readonly attribute.
      *

--- a/contenido/includes/include.frontend.user_edit.php
+++ b/contenido/includes/include.frontend.user_edit.php
@@ -182,9 +182,9 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
 
     $username = new cHTMLTextbox("username", $feuser->get("username"), 40);
     $newpw = new cHTMLPasswordBox("newpd", "", 40);
-    $newpw->setAutocomplete('off');
+    $newpw-->setAutofill(false);
     $newpw2 = new cHTMLPasswordBox("newpd2", "", 40);
-    $newpw2->setAutocomplete('off');
+    $newpw2-->setAutofill(false);
     $active = new cHTMLCheckbox("active", "1");
     $active->setChecked($feuser->get("active"));
 

--- a/contenido/includes/include.frontend.user_edit.php
+++ b/contenido/includes/include.frontend.user_edit.php
@@ -182,9 +182,11 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
 
     $username = new cHTMLTextbox("username", $feuser->get("username"), 40);
     $newpw = new cHTMLPasswordBox("newpd", "", 40);
-    $newpw-->setAutofill(false);
+    $newpw->setAutofill(false);
+    $newpd->setAttribute('autocomplete', 'off');;
     $newpw2 = new cHTMLPasswordBox("newpd2", "", 40);
-    $newpw2-->setAutofill(false);
+    $newpd2->setAttribute('autocomplete', 'off');
+    $newpw2->setAutofill(false);
     $active = new cHTMLCheckbox("active", "1");
     $active->setChecked($feuser->get("active"));
 

--- a/contenido/includes/include.frontend.user_edit.php
+++ b/contenido/includes/include.frontend.user_edit.php
@@ -14,9 +14,12 @@
 
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
+// Global variables, send by the form
+global $idfrontenduser, $username, $newpd, $newpd2, $active;
+
 $page = new cGuiPage("frontend.user_edit");
 
-$feusers = new cApiFrontendUserCollection();
+$feUsers = new cApiFrontendUserCollection();
 
 if (is_array($cfg['plugins']['frontendusers'])) {
     foreach ($cfg['plugins']['frontendusers'] as $plugin) {
@@ -24,6 +27,7 @@ if (is_array($cfg['plugins']['frontendusers'])) {
     }
 }
 
+// NOTE: Don't rename $feuser, plugin "frontendusers" function "frontendusers_valid_from_display" & "frontendusers_valid_from_store" uses it!
 $feuser = new cApiFrontendUser();
 $feuser->loadByPrimaryKey($idfrontenduser);
 
@@ -32,15 +36,15 @@ $oFEGroupMemberCollection->setWhere('idfrontenduser', $idfrontenduser);
 $oFEGroupMemberCollection->addResultField('idfrontendgroup');
 $oFEGroupMemberCollection->query();
 
-// Fetch all groups the user belongs to (no goup, one group, more than one group).
-// The array $aFEGroup can be used in frontenduser plugins to display selfdefined user properties group dependent.
-$aFEGroup = array();
+// Fetch all groups the user belongs to (no group, one group, more than one group).
+// The array $aFEGroup can be used in frontend user plugins to display self defined user properties group dependent.
+$aFEGroup = [];
 while ($oFEGroup = $oFEGroupMemberCollection->next()) {
     $aFEGroup[] = $oFEGroup->get("idfrontendgroup");
 }
 
 if ($action == "frontend_create" && $perm->have_perm_area_action("frontend", "frontend_create")) {
-    $feuser = $feusers->create(" ".i18n("-- new user --"));
+    $feuser = $feUsers->create(" ".i18n("-- new user --"));
     $idfrontenduser = $feuser->get("idfrontenduser");
     // put idfrontenduser of newly created user into superglobals for plugins
     $_GET['idfrontenduser'] = $idfrontenduser;
@@ -70,7 +74,7 @@ JS;
 }
 
 if ($action == "frontend_delete" && $perm->have_perm_area_action("frontend", "frontend_delete")) {
-    $feusers->delete($idfrontenduser);
+    $feUsers->delete($idfrontenduser);
 
     $iterator = $_cecRegistry->getIterator("Contenido.Permissions.FrontendUser.AfterDeletion");
 
@@ -88,7 +92,8 @@ if ($action == "frontend_delete" && $perm->have_perm_area_action("frontend", "fr
 
 if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
     $username = stripslashes(trim($username));
-    $messages = array();
+    $messages = [];
+    $variablesToStore = [];
 
     if ($action == "frontend_save_user" && cString::getStringLength($username) == 0) {
         $page->displayError(i18n("Username can't be empty"));
@@ -99,8 +104,8 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
 
         if ($feuser->get("username") != $username) {
 			$usernameDb = $feuser->escape($username);
-            $feusers->select("username = '".$usernameDb."' and idclient='$client'");
-            if ($feusers->next()) {
+            $feUsers->select("username = '".$usernameDb."' and idclient='$client'");
+            if ($feUsers->next()) {
                 $messages[] = i18n("Could not set new username: Username already exists");
             } else {
                 $feuser->set("username", $username);
@@ -135,19 +140,17 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
                         $wantVariables = call_user_func("frontendusers_".$plugin."_wantedVariables");
 
                         if (is_array($wantVariables)) {
-                            $varArray = array();
-
                             foreach ($wantVariables as $value) {
                                 if (is_array($GLOBALS[$value])) {
                                     foreach ($GLOBALS[$value] as $globKey => $globValue) {
                                         $GLOBALS[$value][$globKey] = stripslashes($globValue);
                                     }
                                 } else {
-                                    $varArray[$value] = stripslashes($GLOBALS[$value]);
+                                    $variablesToStore[$value] = stripslashes($GLOBALS[$value]);
                                 }
                             }
                         }
-                        $store = call_user_func("frontendusers_".$plugin."_store", $varArray);
+                        $store = call_user_func("frontendusers_".$plugin."_store", $variablesToStore);
                     }
                 }
             }
@@ -157,7 +160,7 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
 
         if ($iterator->count() > 0) {
         	while (false !== $chainEntry = $iterator->next()) {
-        		$chainEntry->execute($varArray);
+        		$chainEntry->execute($variablesToStore);
         	}
         }
 
@@ -169,7 +172,6 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
         $page->displayWarning(implode("<br>", $messages)) . "<br>";
     }
 
-
     $form = new cGuiTableForm("properties");
     $form->setVar("frame", $frame);
     $form->setVar("area", $area);
@@ -179,9 +181,11 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
     $form->addHeader(i18n("Edit user"));
 
     $username = new cHTMLTextbox("username", $feuser->get("username"), 40);
-    $newpw    = new cHTMLPasswordBox("newpd", "", 40);
-    $newpw2   = new cHTMLPasswordBox("newpd2", "", 40);
-    $active   = new cHTMLCheckbox("active", "1");
+    $newpw = new cHTMLPasswordBox("newpd", "", 40);
+    $newpw->setAutocomplete('off');
+    $newpw2 = new cHTMLPasswordBox("newpd2", "", 40);
+    $newpw2->setAutocomplete('off');
+    $active = new cHTMLCheckbox("active", "1");
     $active->setChecked($feuser->get("active"));
 
     $form->add(i18n("User name"), $username->render());
@@ -227,7 +231,7 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
         $arrGroups = $feuser->getGroupsForUser();
 
         if (count($arrGroups) > 0) {
-            $aMemberGroups = array();
+            $aMemberGroups = [];
 
             foreach ($arrGroups as $iGroup) {
                 $oMemberGroup = new cApiFrontendGroup($iGroup);

--- a/contenido/includes/include.mycontenido_settings.php
+++ b/contenido/includes/include.mycontenido_settings.php
@@ -134,11 +134,11 @@ $form->add(i18n("Name"), $realname);
 // only
 if ($user->get("password") != 'active_directory_auth') {
     $oldpassword = new cHTMLPasswordbox("oldpassword");
-    $oldpassword->setAutocomplete('off');
+    $oldpassword-->setAutofill(false);
     $newpassword = new cHTMLPasswordbox("newpassword");
-    $newpassword->setAutocomplete('off');
+    $newpassword-->setAutofill(false);
     $newpassword2 = new cHTMLPasswordbox("newpassword2");
-    $newpassword2->setAutocomplete('off');
+    $newpassword2-->setAutofill(false);
 
     $form->add(i18n("Old password"), $oldpassword);
     $form->add(i18n("New password"), $newpassword);

--- a/contenido/includes/include.mycontenido_settings.php
+++ b/contenido/includes/include.mycontenido_settings.php
@@ -14,13 +14,17 @@
 
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
-$cpage = new cGuiPage("mycontenido_settings", "", "2");
+// Global variables, send by the form
+global $newpassword, $oldpassword, $newpassword2, $name, $email, $phonenumber, $street, $zip,
+       $city, $country, $wysi, $format, $formatdate, $formattime;
+
+$page = new cGuiPage("mycontenido_settings", "", "2");
 
 $user = new cApiUser($auth->auth["uid"]);
 
 if ($action == "mycontenido_editself") {
 
-    $notidisplayed = false;
+    $notificationDisplayed = false;
 
     if (!isset($wysi)) {
         $wysi = false;
@@ -38,7 +42,7 @@ if ($action == "mycontenido_editself") {
         }
 
         if ($error !== false) {
-            $cpage->displayError($error);
+            $page->displayError($error);
         } else {
             // New Class User, update password
 
@@ -47,11 +51,11 @@ if ($action == "mycontenido_editself") {
             // user->set("password", md5($newpassword));
 
             if ($iResult == cApiUser::PASS_OK) {
-                $notidisplayed = true;
-                $cpage->displayOk(i18n("Changes saved"));
+                $notificationDisplayed = true;
+                $page->displayOk(i18n("Changes saved"));
             } else {
-                $notidisplayed = true;
-                $cpage->displayError(cApiUser::getErrorString($iResult));
+                $notificationDisplayed = true;
+                $page->displayError(cApiUser::getErrorString($iResult));
             }
         }
     }
@@ -84,26 +88,26 @@ if ($action == "mycontenido_editself") {
     if (true === cString::validateDateFormat($format)) {
         $user->setUserProperty("dateformat", "full", $format);
     } else {
-        $notidisplayed = true;
-        $cpage->displayError(i18n("Date/Time format is not correct."));
+        $notificationDisplayed = true;
+        $page->displayError(i18n("Date/Time format is not correct."));
     }
     if (true === cString::validateDateFormat($formatdate)) {
         $user->setUserProperty("dateformat", "date", $formatdate);
     } else {
-        $notidisplayed = true;
-        $cpage->displayError(i18n("Date format is not correct."));
+        $notificationDisplayed = true;
+        $page->displayError(i18n("Date format is not correct."));
     }
     if (true === cString::validateDateFormat($formattime)) {
         $user->setUserProperty("dateformat", "time", $formattime);
     } else {
-        $notidisplayed = true;
-        $cpage->displayError(i18n("Time format is not correct."));
+        $notificationDisplayed = true;
+        $page->displayError(i18n("Time format is not correct."));
     }
 
-    if ($user->store() && !$notidisplayed) {
-        $cpage->displayOk(i18n("Changes saved"));
-    } else if (!$notidisplayed) {
-        $cpage->displayError(i18n("An error occured while saving user info."));
+    if ($user->store() && !$notificationDisplayed) {
+        $page->displayOk(i18n("Changes saved"));
+    } else if (!$notificationDisplayed) {
+        $page->displayError(i18n("An error occured while saving user info."));
     }
 }
 
@@ -112,7 +116,7 @@ $realname = $user->get('realname');
 if (!empty($realname)) {
     $username .= ' (' . $realname . ')';
 }
-$settingsfor = sprintf(i18n("Settings for %s"), $username);
+$settingsFor = sprintf(i18n("Settings for %s"), $username);
 
 $form = new cGuiTableForm("settings");
 
@@ -121,7 +125,7 @@ $form->setVar("area", $area);
 $form->setVar("action", "mycontenido_editself");
 $form->setVar("frame", $frame);
 
-$form->addHeader($settingsfor);
+$form->addHeader($settingsFor);
 
 $realname = new cHTMLTextbox("name", $user->get("realname"));
 $form->add(i18n("Name"), $realname);
@@ -130,8 +134,11 @@ $form->add(i18n("Name"), $realname);
 // only
 if ($user->get("password") != 'active_directory_auth') {
     $oldpassword = new cHTMLPasswordbox("oldpassword");
+    $oldpassword->setAutocomplete('off');
     $newpassword = new cHTMLPasswordbox("newpassword");
+    $newpassword->setAutocomplete('off');
     $newpassword2 = new cHTMLPasswordbox("newpassword2");
+    $newpassword2->setAutocomplete('off');
 
     $form->add(i18n("Old password"), $oldpassword);
     $form->add(i18n("New password"), $newpassword);
@@ -160,9 +167,7 @@ $wysiwyg = new cHTMLCheckbox("wysi", 1);
 $wysiwyg->setChecked($user->get("wysi"));
 $wysiwyg->setLabelText(i18n("Use WYSIWYG Editor"));
 
-$form->add(i18n("Options"), array(
-    $wysiwyg
-));
+$form->add(i18n("Options"), [$wysiwyg]);
 
 $formathint = "<br>" . i18n("The format is equal to PHP's date() function.");
 $formathint .= "<br>";
@@ -188,26 +193,24 @@ $format3 = new cHTMLTextbox("formattime", $user->getUserProperty("dateformat", "
 
 $infoButton = new cGuiBackendHelpbox(i18n("FORMAT_DATE_TIME"));
 
-$form->add(i18n("Date/Time format"), array(
+$form->add(i18n("Date/Time format"), [
     $format,
     ' ',
     $infoButton->render(),
     $formathint
-));
+]);
 $infoButton->setHelpText(i18n("FORMAT_DATE"));
-$form->add(i18n("Date format"), array(
+$form->add(i18n("Date format"), [
     $format2,
     ' ',
     $infoButton->render()
-));
+]);
 $infoButton->setHelpText(i18n("FORMATE_TIME"));
-$form->add(i18n("Time format"), array(
+$form->add(i18n("Time format"), [
     $format3,
     ' ',
     $infoButton->render()
-));
+]);
 
-$cpage->setContent(array(
-    $form
-));
-$cpage->render();
+$page->setContent([$form]);
+$page->render();

--- a/contenido/includes/include.mycontenido_settings.php
+++ b/contenido/includes/include.mycontenido_settings.php
@@ -134,11 +134,14 @@ $form->add(i18n("Name"), $realname);
 // only
 if ($user->get("password") != 'active_directory_auth') {
     $oldpassword = new cHTMLPasswordbox("oldpassword");
-    $oldpassword-->setAutofill(false);
+    $oldpassword->setAutofill(false);
+    $oldpassword->setAttribute('autocomplete', 'off');
     $newpassword = new cHTMLPasswordbox("newpassword");
-    $newpassword-->setAutofill(false);
+    $newpassword->setAutofill(false);
+    $newpassword->setAttribute('autocomplete', 'off');
     $newpassword2 = new cHTMLPasswordbox("newpassword2");
-    $newpassword2-->setAutofill(false);
+    $newpassword2->setAutofill(false);
+    $newpassword2->setAttribute('autocomplete', 'off');
 
     $form->add(i18n("Old password"), $oldpassword);
     $form->add(i18n("New password"), $newpassword);

--- a/contenido/includes/include.rights_create.php
+++ b/contenido/includes/include.rights_create.php
@@ -169,13 +169,14 @@ $tpl->next();
 
 $tpl->set('d', 'CATNAME', i18n("New password"));
 $oTxtPass = new cHTMLPasswordbox('password', '', 40, 255);
-$oTxtPass->setAttribute('autocomplete', 'off');
 $oTxtPass->setAutofill(false);
+$oTxtPass->setAttribute('autocomplete', 'off');
 $tpl->set('d', 'CATFIELD', $oTxtPass->render());
 $tpl->next();
 
 $tpl->set('d', 'CATNAME', i18n("Confirm new password"));
 $oTxtWord = new cHTMLPasswordbox('passwordagain', '', 40, 255);
+$oTxtWord->setAutofill(false);
 $oTxtWord->setAttribute('autocomplete', 'off');
 $tpl->set('d', 'CATFIELD', $oTxtWord->render());
 $tpl->next();

--- a/contenido/includes/include.rights_create.php
+++ b/contenido/includes/include.rights_create.php
@@ -170,6 +170,7 @@ $tpl->next();
 $tpl->set('d', 'CATNAME', i18n("New password"));
 $oTxtPass = new cHTMLPasswordbox('password', '', 40, 255);
 $oTxtPass->setAttribute('autocomplete', 'off');
+$oTxtPass->setAutofill(false);
 $tpl->set('d', 'CATFIELD', $oTxtPass->render());
 $tpl->next();
 

--- a/contenido/includes/include.rights_overview.php
+++ b/contenido/includes/include.rights_overview.php
@@ -16,6 +16,8 @@
 
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
+global $mclient, $msysadmin, $mlang;
+
 if (!($perm->have_perm_area_action($area, $action) || $perm->have_perm_area_action('user', $action))) {
     // access denied
     $notification->displayNotification("error", i18n("Permission denied"));
@@ -34,9 +36,10 @@ if (!isset($request['userid'])) {
     return;
 }
 
-$aPerms = array();
+$aPerms = [];
 $bError = false;
 $sNotification = '';
+$belang = cRegistry::getBackendLanguage();
 
 // Action delete user
 if ($action == 'user_delete') {
@@ -75,26 +78,26 @@ if ($action == 'user_edit') {
     if (is_array($mclient) && count($mclient) > 0) {
 
         // Prevent setting the permissions for a client without a language of that client
-        foreach ($mclient as $selectedclient) {
+        foreach ($mclient as $selectedClient) {
 
             // Get all available languages for selected client
             $clientLanguageCollection = new cApiClientLanguageCollection();
-            $availablelanguages = $clientLanguageCollection->getLanguagesByClient($selectedclient);
+            $availableLanguages = $clientLanguageCollection->getLanguagesByClient($selectedClient);
 
             if (!is_array($mlang) || count($mlang) == 0) {
                 // User has no selected language
                 $sNotification = $notification->returnNotification("warning", i18n("Please select a language for your selected client."));
                 $bError = true;
-            } else if ($availablelanguages == false) {
+            } else if ($availableLanguages == false) {
                 // Client has no assigned language(s)
                 $sNotification = $notification->returnNotification("warning", i18n("You can only assign users to a client with languages."));
                 $bError = true;
             } else {
 
                 // Client has one or more assigned language(s)
-                foreach ($mlang as $selectedlanguage) {
+                foreach ($mlang as $selectedLanguage) {
 
-                    if (!$clientLanguageCollection->hasLanguageInClients($selectedlanguage, $mclient)) {
+                    if (!$clientLanguageCollection->hasLanguageInClients($selectedLanguage, $mclient)) {
                         // Selected language are not assigned to selected client
                         $sNotification = $notification->returnNotification("warning", i18n("You have to select a client with a language of that client."));
                         $bError = true;
@@ -220,12 +223,14 @@ if ($msysadmin || $oUser->getField('password') != 'active_directory_auth') {
     $tpl->set('d', 'ROW_ID', "password");
     $tpl->set('d', 'CATNAME', i18n("New password"));
     $oTxtPass = new cHTMLPasswordbox('password', '', 40, 255);
+    $oTxtPass->setAutocomplete('off');
     $tpl->set('d', 'CATFIELD', $oTxtPass->render());
     $tpl->next();
 
     $tpl->set('d', 'ROW_ID', "confirm_password");
     $tpl->set('d', 'CATNAME', i18n("Confirm new password"));
     $oTxtWord = new cHTMLPasswordbox('passwordagain', '', 40, 255);
+    $oTxtWord->setAutocomplete('off');
     $tpl->set('d', 'CATFIELD', $oTxtWord->render());
     $tpl->next();
 }

--- a/contenido/includes/include.rights_overview.php
+++ b/contenido/includes/include.rights_overview.php
@@ -223,14 +223,16 @@ if ($msysadmin || $oUser->getField('password') != 'active_directory_auth') {
     $tpl->set('d', 'ROW_ID', "password");
     $tpl->set('d', 'CATNAME', i18n("New password"));
     $oTxtPass = new cHTMLPasswordbox('password', '', 40, 255);
-    $oTxtPass-->setAutofill(false);
+    $oTxtPass->setAutofill(false);
+    $oTxtPass->setAttribute('autocomplete', 'off');
     $tpl->set('d', 'CATFIELD', $oTxtPass->render());
     $tpl->next();
 
     $tpl->set('d', 'ROW_ID', "confirm_password");
     $tpl->set('d', 'CATNAME', i18n("Confirm new password"));
     $oTxtWord = new cHTMLPasswordbox('passwordagain', '', 40, 255);
-    $oTxtWord-->setAutofill(false);
+    $oTxtWord->setAutofill(false);
+    $oTxtWord->setAttribute('autocomplete', 'off');
     $tpl->set('d', 'CATFIELD', $oTxtWord->render());
     $tpl->next();
 }

--- a/contenido/includes/include.rights_overview.php
+++ b/contenido/includes/include.rights_overview.php
@@ -223,14 +223,14 @@ if ($msysadmin || $oUser->getField('password') != 'active_directory_auth') {
     $tpl->set('d', 'ROW_ID', "password");
     $tpl->set('d', 'CATNAME', i18n("New password"));
     $oTxtPass = new cHTMLPasswordbox('password', '', 40, 255);
-    $oTxtPass->setAutocomplete('off');
+    $oTxtPass-->setAutofill(false);
     $tpl->set('d', 'CATFIELD', $oTxtPass->render());
     $tpl->next();
 
     $tpl->set('d', 'ROW_ID', "confirm_password");
     $tpl->set('d', 'CATNAME', i18n("Confirm new password"));
     $oTxtWord = new cHTMLPasswordbox('passwordagain', '', 40, 255);
-    $oTxtWord->setAutocomplete('off');
+    $oTxtWord-->setAutofill(false);
     $tpl->set('d', 'CATFIELD', $oTxtWord->render());
     $tpl->next();
 }

--- a/contenido/includes/include.system_configuration.php
+++ b/contenido/includes/include.system_configuration.php
@@ -35,13 +35,12 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  *
  * @return array
  *         associative array with the label and the input field
- * 
+ *
  * @throws cException
  */
 function renderSelectProperty($name, $possibleValues, $value, $label, $width = 328) {
-    global $auth;
-
-    $return = array();
+    $auth = cRegistry::getAuth();
+    $return = [];
 
     if (count($possibleValues) === 2 && (in_array('true', $possibleValues) && in_array('false', $possibleValues) || in_array('enabled', $possibleValues) && in_array('disabled', $possibleValues) || in_array('0', $possibleValues) && in_array('1', $possibleValues))) {
         // render a checkbox if there are only the values true and false
@@ -121,22 +120,20 @@ function renderSelectProperty($name, $possibleValues, $value, $label, $width = 3
  *         the name of the corresponding input element
  * @param int $width
  *         the width in pixel
- * @param string $seperator
- *         the seperator which is written at the end of the label
+ * @param string $separator
+ *         the separator which is written at the end of the label
  * @param string $float
  * @return string
  *         the rendered cHTMLLabel element
  */
-function renderLabel($text, $name, $width = 280, $seperator = ':', $float = '') {
-    $label = new cHTMLLabel($text . $seperator, $name);
+function renderLabel($text, $name, $width = 280, $separator = ':', $float = '') {
+    $label = new cHTMLLabel($text . $separator, $name);
     $label->setClass("sys_config_txt_lbl");
     if ($float != '') {
         $label->setStyle('width:' . $width . 'px;' . 'float:' . $float . ';');
     } else {
         $label->setStyle('width:' . $width . 'px;');
     }
-
-
 
     return $label->render();
 }
@@ -158,23 +155,25 @@ function renderLabel($text, $name, $width = 280, $seperator = ':', $float = '') 
  *         associative array with the label and the input field
  */
 function renderTextProperty($name, $value, $label, $password = false) {
-    global $auth;
+    $auth = cRegistry::getAuth();
 
-    $textbox = new cHTMLTextbox($name, conHtmlSpecialChars($value), 50, 96);
-    $textbox->updateAttribute('style', 'width:322px');
-    // disable the textbox if user is not a sysadmin
-    if (cString::findFirstPos($auth->auth['perm'], 'sysadmin') === false) {
-        $textbox->updateAttribute('disabled', 'true');
-    }
     if ($password === true) {
-        $textbox->updateAttribute('type', 'password');
+        $textBox = new cHTMLPasswordbox($name, conHtmlSpecialChars($value), 50, 96);
+        $textBox->setAutocomplete('off');
+    } else {
+        $textBox = new cHTMLTextbox($name, conHtmlSpecialChars($value), 50, 96);
+    }
+    $textBox->updateAttribute('style', 'width:322px');
+
+    // disable the text box if user is not a sysadmin
+    if (cString::findFirstPos($auth->auth['perm'], 'sysadmin') === false) {
+        $textBox->updateAttribute('disabled', 'true');
     }
 
-    $return = array();
-    $return['input'] = $textbox->render();
-    $return['label'] = renderLabel($label, $name);
-
-    return $return;
+    return [
+        'input' => $textBox->render(),
+        'label' => renderLabel($label, $name),
+    ];
 }
 
 $page = new cGuiPage('system_configuration', '', '1');
@@ -247,7 +246,7 @@ if (cString::findFirstPos($auth->auth['perm'], 'sysadmin') === false) {
     $form->setActionButton('submit', cRegistry::getBackendUrl() . 'images/but_ok_off.gif', i18n("You are not sysadmin. You can't change these settings."), 's');
 }
 
-$groups = array();
+$groups = [];
 $currentGroup = '';
 $leftContent = '';
 // iterate over all property types

--- a/contenido/includes/include.system_configuration.php
+++ b/contenido/includes/include.system_configuration.php
@@ -159,7 +159,7 @@ function renderTextProperty($name, $value, $label, $password = false) {
 
     if ($password === true) {
         $textBox = new cHTMLPasswordbox($name, conHtmlSpecialChars($value), 50, 96);
-        $textBox->setAutocomplete('off');
+        $textBox-->setAutofill(false);
     } else {
         $textBox = new cHTMLTextbox($name, conHtmlSpecialChars($value), 50, 96);
     }

--- a/contenido/includes/include.system_configuration.php
+++ b/contenido/includes/include.system_configuration.php
@@ -159,7 +159,8 @@ function renderTextProperty($name, $value, $label, $password = false) {
 
     if ($password === true) {
         $textBox = new cHTMLPasswordbox($name, conHtmlSpecialChars($value), 50, 96);
-        $textBox-->setAutofill(false);
+        $textBox->setAutofill(false);
+        $textBox->setAttribute('autocomplete', 'off');
     } else {
         $textBox = new cHTMLTextbox($name, conHtmlSpecialChars($value), 50, 96);
     }

--- a/contenido/plugins/siwecos/templates/template.right_bottom.tpl
+++ b/contenido/plugins/siwecos/templates/template.right_bottom.tpl
@@ -28,7 +28,17 @@
                 *
             </td>
             <td nowrap="nowrap" valign="top" align="left">
-                <input type="password" id="password" name="password" value="{$password}">
+                <input type="password" id="password" name="password" value="{$password}" autocomplete="off" readonly="readonly">
+                <script type="text/javascript">
+                    (function(Con, $) {
+                        $(function() {
+                            // Remove readonly attribute on focus
+                            $("#password").on("focus", function() {
+                                $(this).prop("readonly", false);
+                            });
+                        });
+                    })(Con, Con.$);
+                </script>
             </td>
         </tr>
         <tr class="2">

--- a/test/contenido/html/cHtmlPasswordBoxTest.php
+++ b/test/contenido/html/cHtmlPasswordBoxTest.php
@@ -121,12 +121,16 @@ class cHtmlPasswordBoxTest extends cTestingTestCase
         $this->assertSame('testInitValue', $pwBox->getAttribute('value'));
     }
 
-    public function testAutocomplete() {
-        // Test autocomplete="off"
+    public function testAutofill() {
+        // Test default autofill
         $pwBox = new cHTMLPasswordbox('testName', 'testInitValue');
-        // Setting autocomplete="off" sets also readonly="readonly" & renders script together with the element
-        $pwBox->setAutocomplete('off');
-        $this->assertSame('off', $pwBox->getAttribute('autocomplete'));
+        $this->assertTrue($this->_readAttribute($pwBox, '_autofill'));
+
+        // Test autofill false
+        $pwBox = new cHTMLPasswordbox('testName', 'testInitValue');
+        // Setting autofill to false sets also readonly="readonly" & renders script together with the element
+        $pwBox->setAutofill(false);
+        $this->assertFalse($this->_readAttribute($pwBox, '_autofill'));
 
         $html = $pwBox->toHtml();
         $this->assertSame('readonly', $pwBox->getAttribute('readonly'));
@@ -134,11 +138,11 @@ class cHtmlPasswordBoxTest extends cTestingTestCase
         $this->assertStringContainsString('$("#' . $pwBox->getID() . '").on("focus", function() {', $html);
         $this->assertStringContainsString('$(this).prop("readonly", false);', $html);
 
-        // Test autocomplete="on"
+        // Test autofill true
         $pwBox = new cHTMLPasswordbox('testName', 'testInitValue');
-        // Setting autocomplete="on" sets also readonly="readonly" & renders script together with the element
-        $pwBox->setAutocomplete('on');
-        $this->assertSame('on', $pwBox->getAttribute('autocomplete'));
+        // Setting autofill true sets also readonly="readonly" & renders script together with the element
+        $pwBox->setAutofill(true);
+        $this->assertTrue($this->_readAttribute($pwBox, '_autofill'));
 
         $html = $pwBox->toHtml();
         $this->assertNull($pwBox->getAttribute('readonly'));

--- a/test/contenido/html/cHtmlPasswordBoxTest.php
+++ b/test/contenido/html/cHtmlPasswordBoxTest.php
@@ -120,4 +120,30 @@ class cHtmlPasswordBoxTest extends cTestingTestCase
         $pwBox->setValue('testInitValue');
         $this->assertSame('testInitValue', $pwBox->getAttribute('value'));
     }
+
+    public function testAutocomplete() {
+        // Test autocomplete="off"
+        $pwBox = new cHTMLPasswordbox('testName', 'testInitValue');
+        // Setting autocomplete="off" sets also readonly="readonly" & renders script together with the element
+        $pwBox->setAutocomplete('off');
+        $this->assertSame('off', $pwBox->getAttribute('autocomplete'));
+
+        $html = $pwBox->toHtml();
+        $this->assertSame('readonly', $pwBox->getAttribute('readonly'));
+        $this->assertStringContainsString('<script', $html);
+        $this->assertStringContainsString('$("#' . $pwBox->getID() . '").on("focus", function() {', $html);
+        $this->assertStringContainsString('$(this).prop("readonly", false);', $html);
+
+        // Test autocomplete="on"
+        $pwBox = new cHTMLPasswordbox('testName', 'testInitValue');
+        // Setting autocomplete="on" sets also readonly="readonly" & renders script together with the element
+        $pwBox->setAutocomplete('on');
+        $this->assertSame('on', $pwBox->getAttribute('autocomplete'));
+
+        $html = $pwBox->toHtml();
+        $this->assertNull($pwBox->getAttribute('readonly'));
+        $this->assertStringNotContainsString('<script', $html);
+        $this->assertStringNotContainsString('$("#' . $pwBox->getID() . '").on("focus", function() {', $html);
+        $this->assertStringNotContainsString('$(this).prop("readonly", false);', $html);
+    }
 }

--- a/test/lib/class.testing.test.case.php
+++ b/test/lib/class.testing.test.case.php
@@ -96,13 +96,13 @@ abstract class cTestingTestCase extends TestCase {
      *      - https://github.com/sebastianbergmann/phpunit/issues/3338
      *      - https://github.com/sebastianbergmann/phpunit/issues/3339
      */
-    protected function _readAttribute($bject, $attributeName) {
+    protected function _readAttribute($object, $attributeName) {
 //        return Assert::readAttribute($classOrObject, $attributeName);
-        $reflector = new ReflectionObject($bject);
+        $reflector = new ReflectionObject($object);
         $property = $reflector->getProperty($attributeName);
         $property->setAccessible(true);
 
-        return $property->getValue($bject);
+        return $property->getValue($object);
 
     }
 


### PR DESCRIPTION
All input fields of type password in the backend, except the one for the backend login, will be rendered with the `readonly` attribute. This attribute will be removed via JavaScript, if the field gets the focus. This prevents the browser or password manager from filling the fields automatically.