### PR TITLE
Update include.mod_translate.php

### DIFF
--- a/contenido/includes/include.mod_translate.php
+++ b/contenido/includes/include.mod_translate.php
@@ -55,7 +55,7 @@ if (!isset($idmodtranslation)) {
 
 // Get the mi18n strings from module input/output
 $strings = $module->parseModuleForStringsLoadFromFile($cfg, $client, $lang);
-if (is_array($strings)) {
+if (!is_array($strings)) {
     $strings = [];
 }
 


### PR DESCRIPTION
parseModuleForStringsLoadFromFile returns an array of translation strings, we noarmaly want to keep. if we have no array, we want to initialize it. in this actual code the "!" is missing

Actual code resets translation strings.