### PR TITLE
Removed stripslashes functionality on $_REQUEST variables in include.…

### DIFF
--- a/contenido/includes/include.clientsettings.php
+++ b/contenido/includes/include.clientsettings.php
@@ -23,11 +23,7 @@ $oPage = new cGuiPage("clientsettings");
 $oList = new cGuiScrollList();
 
 // @TODO Find a general solution for this!
-if (defined('CON_STRIPSLASHES')) {
-    $request = cString::stripSlashes($_REQUEST);
-} else {
-    $request = $_REQUEST;
-}
+$request = $_REQUEST;
 
 $idclientslang = isset($request["idclientslang"]) ? cSecurity::toInteger($request["idclientslang"]) : 0;
 $action = isset($request["action"]) ? $request["action"] : '';

--- a/contenido/includes/include.systemsettings.php
+++ b/contenido/includes/include.systemsettings.php
@@ -26,11 +26,7 @@ $aManagedValues = array(
 );
 
 // @TODO Find a general solution for this!
-if (defined('CON_STRIPSLASHES')) {
-    $request = cString::stripSlashes($_REQUEST);
-} else {
-    $request = $_REQUEST;
-}
+$request = $_REQUEST;
 
 // @TODO: Check possibility to use $perm->isSysadmin()
 $isSysadmin = (false !== cString::findFirstPos($auth->auth["perm"], "sysadmin"));


### PR DESCRIPTION
…clientsettings.php and include.systemsettings.php

Details:
in globals_off.inc.php, $_REQUEST is never included in adding backslashes to escape its values. BUT in both files now patched, $_REQUEST variables were stripped from backslashes as if $_REQUEST had been changed. Therefore, values or names with backslashes could never be saved.
With these changes applicable, the following menus should allow to save backslashes: 
Administration - client - clientsettings (but not the other two tabs in "client" menu)
Administration - system - configuration 
Administration - system - expert configuration
To avoid problems with older contenido code, $_REQUEST is not generally prevented from executing stripslashes functionality. This only applies to specific ranges of backend inputs.