### PR TITLE
Display module name in all tabs of module editing options

### DIFF
--- a/contenido/includes/include.mod_edit_form.php
+++ b/contenido/includes/include.mod_edit_form.php
@@ -188,7 +188,7 @@ if (!$perm->have_perm_area_action_item("mod_edit", "mod_edit", $idmod)) {
         $form->setVar("action", "mod_edit");
     }
 
-    $form->addHeader(i18n("Edit module"));
+    $form->addHeader(i18n("Edit module") . " &quot;". conHtmlSpecialChars($module->get('name')). "&quot;");
 
     $name = new cHTMLTextbox("name", conHtmlSpecialChars(stripslashes($module->get("name"))), 60);
     $descr = new cHTMLTextarea("descr", str_replace(array(

--- a/contenido/includes/include.mod_history.php
+++ b/contenido/includes/include.mod_history.php
@@ -27,6 +27,8 @@ if ($idmod == '') {
     $idmod = $_REQUEST['idmod'];
 }
 
+$module = new cApiModule($idmod);
+
 $bDeleteFile = false;
 $oPage = new cGuiPage('mod_history');
 
@@ -82,7 +84,7 @@ $sSelectBox = $oVersion->buildSelectBox("mod_history", i18n("Module History"), i
 // Generate Form
 $oForm = new cGuiTableForm("mod_display");
 $oForm->setTableID('mod_history');
-$oForm->addHeader(i18n("Edit module"));
+$oForm->addHeader(i18n("Edit module") . " &quot;". conHtmlSpecialChars($module->get('name')). "&quot;");
 $oForm->setVar("area", "mod_history");
 $oForm->setVar("frame", $frame);
 $oForm->setVar("idmod", $idmod);

--- a/contenido/includes/include.mod_import_export.php
+++ b/contenido/includes/include.mod_import_export.php
@@ -116,7 +116,7 @@ if($readOnly) {
 $form2 = new cGuiTableForm("export");
 $form2->setVar("action", "mod_importexport_module");
 $form2->setVar("use_encoding", "false");
-$form2->addHeader("Import/Export");
+$form2->addHeader("Import/Export" . " &quot;". conHtmlSpecialChars($module->get('name')). "&quot;");
 $form2->add(i18n("Mode"), array(
     $export,
     "<br>",

--- a/contenido/includes/include.mod_script.php
+++ b/contenido/includes/include.mod_script.php
@@ -167,6 +167,7 @@ if ((!$readOnly) && $actionRequest == $sActionEdit && $_REQUEST['status'] == 'se
 if (isset($actionRequest)) {
     $fileEncoding = getEffectiveSetting('encoding', 'file_encoding', 'UTF-8');
     $sAction = ($bEdit) ? $sActionEdit : $actionRequest;
+    $module = new cApiModule($idmod);
 
     if ($actionRequest == $sActionEdit
     && cFileHandler::exists($path . $sFilename)) {
@@ -182,7 +183,7 @@ if (isset($actionRequest)) {
 
     $form = new cGuiTableForm('file_editor');
     $form->setTableID('mod_javascript');
-    $form->addHeader(i18n('Edit file'));
+    $form->addHeader(i18n('Edit file') . " &quot;". conHtmlSpecialChars($module->get('name')). "&quot;");
     $form->setVar('area', $area);
     $form->setVar('action', $sAction);
     $form->setVar('frame', $frame);

--- a/contenido/includes/include.mod_style.php
+++ b/contenido/includes/include.mod_style.php
@@ -167,6 +167,7 @@ if ((!$readOnly) && $actionRequest == $sActionEdit && $_REQUEST['status'] == 'se
 if (isset($actionRequest)) {
 
     $sAction = ($bEdit) ? $sActionEdit : $actionRequest;
+    $module = new cApiModule($idmod);
 
     $fileEncoding = getEffectiveSetting('encoding', 'file_encoding', 'UTF-8');
 
@@ -186,7 +187,7 @@ if (isset($actionRequest)) {
 
     $form = new cGuiTableForm('file_editor');
     $form->setTableID('mod_style');
-    $form->addHeader(i18n('Edit file'));
+    $form->addHeader(i18n('Edit file') . " &quot;". conHtmlSpecialChars($module->get('name')). "&quot;");
     $form->setVar('area', $area);
     $form->setVar('action', $sAction);
     $form->setVar('frame', $frame);

--- a/contenido/includes/include.mod_template.php
+++ b/contenido/includes/include.mod_template.php
@@ -17,6 +17,7 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
 cInclude("external", "codemirror/class.codemirror.php");
 cInclude("includes", "functions.file.php");
 $sFileType = "html";
+$module = new cApiModule($idmod);
 
 $readOnly = (getEffectiveSetting("client", "readonly", "false") == "true");
 
@@ -37,7 +38,7 @@ if (true === cRegistry::getConfigValue('simulate_magic_quotes')) {
 
 $page = new cGuiPage("mod_template");
 $tpl->reset();
-
+$page->displayInfo(i18n('Edit file') . " &quot;". conHtmlSpecialChars($module->get('name')) . "&quot;");
 if (!is_object($notification)) {
     $notification = new cGuiNotification();
 }


### PR DESCRIPTION
Added module name to all tabs of module editing options. The name is shown in one of the table headers; only exception is "template" tab where I couldn't find an option to do the same. Therefore, I used cGuiPage's ->displayInfo functionality for the time being. Not elegant, but the info is there. If someone knows how to change this to be more inline with the rest, plz let me know!