### PR TITLE
#56 Content Articles: Publish Date now updated when switching on or off

### DIFF
--- a/contenido/includes/include.con_art_overview.php
+++ b/contenido/includes/include.con_art_overview.php
@@ -652,7 +652,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
                         $value = $modified;
                         break;
                     case "publisheddate":
-                        if ('1' === $oArtLang->get('online')) {
+                        if (1 === $oArtLang->get('online')) {
                             $value = $published;
                         } else {
                             $value = i18n("not yet published");

--- a/contenido/includes/include.con_art_overview.php
+++ b/contenido/includes/include.con_art_overview.php
@@ -652,7 +652,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
                         $value = $modified;
                         break;
                     case "publisheddate":
-                        if (1 === $oArtLang->get('online')) {
+                        if (1 === cSecurity::toInteger($oArtLang->get('online'))) {
                             $value = $published;
                         } else {
                             $value = i18n("not yet published");


### PR DESCRIPTION
include.con_art_overview.php, line 655: the check on publishing state was done on a string ('1') not on a numeric (1) which caused the value to be false at all times when changing the publishing state of an article by clicking on the icon in the article list. Fixed.