### PR TITLE
#47 SEO-tab: Optimize info icon and input field for URL shortener

### DIFF
--- a/contenido/plugins/url_shortener/includes/functions.url_shortener.php
+++ b/contenido/plugins/url_shortener/includes/functions.url_shortener.php
@@ -41,10 +41,12 @@ function piUsEditFormAdditionalRows($idart, $idlang, $idclient, $disabled) {
     $td->setContent(i18n('Short URL', 'url_shortener'));
     $tr->appendContent($td);
 
+	$infoButton = new cGuiBackendHelpbox(i18n('INFO', 'url_shortener'));
+
     $td = new cHTMLTableData();
-    $td->setClass('text_medium');
-    $textbox = new cHTMLTextbox('url_shortener_shorturl', $shortUrl->get('shorturl'), 24, '', '', $disabled);
-    $td->setContent($textbox.' <img class="vAlignMiddle" title="'. i18n('INFO', 'url_shortener') .'" src="images/info.gif" alt="">');
+    $td->setClass('leftData');
+    $textbox = new cHTMLTextbox('url_shortener_shorturl', $shortUrl->get('shorturl'), 24, '', '', $disabled, NULL, '', 'textField');
+    $td->setContent($textbox . ' ' . $infoButton->render());
     $tr->appendContent($td);
 
     return $tr->render();


### PR DESCRIPTION
The way the additional SEO line was setup in functions.url_shortener.php wasn't in line anymore with standard procedures for that page. Amended it to standard info button production/inclusion, amended table class name and input field classes.