### PR TITLE
#215 Corrected order of sections and subitems in user and group right…

### DIFF
--- a/contenido/classes/class.rights.php
+++ b/contenido/classes/class.rights.php
@@ -495,7 +495,7 @@ class cRights
         try {
             $rights = [];
 
-            $areas->select('relevant = 1 AND online = 1 AND name != "login"');
+            $areas->select('relevant = 1 AND online = 1 AND name != "login" ORDER BY idarea ASC');
             while ($area = $areas->next()) {
                 $right = [
                     'perm'     => $area->get('name'),
@@ -503,13 +503,13 @@ class cRights
                 ];
 
                 // get location
-                $navSubs->select('idarea = ' . (int)$area->get('idarea'));
+                $navSubs->select('idarea = ' . (int)$area->get('idarea') . ' ORDER BY idarea ASC');
                 if ($navSubItem = $navSubs->next()) {
                     $right['location'] = $navSubItem->get('location');
                 }
 
                 // get relevant actions
-                $actions->select('relevant = 1 AND idarea = ' . (int)$area->get('idarea'));
+                $actions->select('relevant = 1 AND idarea = ' . (int)$area->get('idarea') . ' ORDER BY idarea ASC');
                 while ($action = $actions->next()) {
                     $right['action'][] = $action->get('name');
                 }


### PR DESCRIPTION
…s area lists

Most likely buggy since 4.10.1 at least. Missing "ORDER BY" clauses in class.rights.php messed up the required order within the rights-list-array. Fixed and checked in develop branch.