### PR TITLE
#208 Detect and log missing plugins that are activated in database table

### DIFF
--- a/contenido/includes/functions.includePluginConf.php
+++ b/contenido/includes/functions.includePluginConf.php
@@ -33,6 +33,8 @@ if ($cfg['debug']['disable_plugins'] === false) {
 
         if (is_dir($pluginFolder . $pluginName . '/')) {
             $plugins[] = $pluginName;
+        } else {
+        cWarning(__FILE__, __LINE__, "Plugin <" . $pluginName. "> is activated in database, but folder does not exist. This leads to errors e.g. in user or group rights area settings.");		
         }
     }
 }
@@ -48,7 +50,9 @@ foreach ($plugins as $pluginName) {
 
     if (cFileHandler::exists($pluginConfigFile)) {
         include_once($pluginConfigFile);
-    }
+    } else {
+        cWarning(__FILE__, __LINE__, "Plugin <" . $pluginName. "> configuration file config.plugin.php is missing.");		
+	}
 }
 
 // Load legacy plugins frontendusers and frontendlogic

--- a/contenido/includes/functions.includePluginConf.php
+++ b/contenido/includes/functions.includePluginConf.php
@@ -34,7 +34,7 @@ if ($cfg['debug']['disable_plugins'] === false) {
         if (is_dir($pluginFolder . $pluginName . '/')) {
             $plugins[] = $pluginName;
         } else {
-        cWarning(__FILE__, __LINE__, "Plugin <" . $pluginName. "> is activated in database, but folder does not exist. This leads to errors e.g. in user or group rights area settings.");		
+            cWarning(__FILE__, __LINE__, "Plugin <" . $pluginName. "> is activated in database, but folder does not exist. This leads to errors e.g. in user or group rights area settings.");		
         }
     }
 }
@@ -52,7 +52,7 @@ foreach ($plugins as $pluginName) {
         include_once($pluginConfigFile);
     } else {
         cWarning(__FILE__, __LINE__, "Plugin <" . $pluginName. "> configuration file config.plugin.php is missing.");		
-	}
+    }
 }
 
 // Load legacy plugins frontendusers and frontendlogic


### PR DESCRIPTION
Problem summary: when swapping contenido folders (e.g. in case of an update/upgrade), it might happen that previously (and still) activated plugins are physically not yet present in the new contenido folder. If so, this causes multiple problems at unexpected places. Some backend menus won't work or don't show their content pages. 
This extended plugin check routine logs error messages if a) a plugin folder for an activated plugin is not there and b) the folder is there, but config.plugin.php is not available, for whatever reason. 