### PR TITLE
#40 Don't use the variable $sValue

### DIFF
--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -1085,7 +1085,7 @@ function buildArticleSelect($sName, $iIdCat, $sValue) {
     if (!isset($cache)) {
         $cache = [];
     }
-    $cacheKey = implode('/', [$lang, $sName, $iIdCat, $sValue]);
+    $cacheKey = implode('/', [$lang, $sName, $iIdCat]);
 
     if (isset($cache[$cacheKey])) {
         // Get data from cache


### PR DESCRIPTION
Don't use the variable $sValue to create the cache key in buildArticleSelect().