### PR TITLE
Fix: Similarity is never set for search

### DIFF
--- a/contenido/classes/search/class.search.php
+++ b/contenido/classes/search/class.search.php
@@ -444,7 +444,7 @@ class cSearch extends cSearchBaseAbstract {
                                 $this->_searchResult[$artid]['search'][] = $searchword;
                                 $this->_searchResult[$artid]['occurence'][] = $string[1];
                                 $this->_searchResult[$artid]['debug_similarity'][] = $percent;
-                                if (isset($this->_searchResult[$artid]['similarity']) && $similarity > $this->_searchResult[$artid]['similarity']) {
+                                if ($similarity > ($this->_searchResult[$artid]['similarity'] ?? 0)) {
                                     $this->_searchResult[$artid]['similarity'] = $similarity;
                                 }
                             }


### PR DESCRIPTION
similarity is never set because it needs to exists (isset) before it can be set.
I fixed it with null coalescing fallback to similarity = 0