### PR TITLE
Update indexes.sql con_upl from MyIsam to InnoDB just before making indexes

### DIFF
--- a/setup/data/indexes.sql
+++ b/setup/data/indexes.sql
@@ -51,6 +51,7 @@ ALTER TABLE `!PREFIX!_template` ADD INDEX idtplcfg (idtplcfg);
 
 ALTER TABLE `!PREFIX!_template_conf` ADD INDEX idtplcfg (idtplcfg);
 
+ALTER TABLE `!PREFIX!_upl` ENGINE = InnoDB;
 ALTER TABLE `!PREFIX!_upl` ADD INDEX idclient (idclient);
 ALTER TABLE `!PREFIX!_upl` ADD INDEX filesync (idclient, filename, dirname);
 ALTER TABLE `!PREFIX!_properties` ADD INDEX index_client (idclient);


### PR DESCRIPTION
Updating older CONTENIDO Versions doesn't change the Table-Engine, so MyIsam Engine will stay. Setup will stop with failure at older con_upl Tables with MyIsam engine holding long filenames, because MyIsam has only 1000 bytes storage for that data.
InnoDB has 3000 bytes storage.
https://github.com/CONTENIDO/CONTENIDO/issues/243

It worked at updates yesterday, two weeks ago and simmilar in this case too:
https://forum.contenido.org/viewtopic.php?f=115&t=44634