### PR TITLE
#264 Resolve redundant admin checks.

### DIFF
--- a/contenido/classes/auth/class.auth.handler.backend.php
+++ b/contenido/classes/auth/class.auth.handler.backend.php
@@ -53,7 +53,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
      * Includes a file which displays the login form.
      *
      * @see cAuthHandlerAbstract::displayLoginForm()
-     * 
+     *
      * @throws cDbException
      * @throws cException
      * @throws cInvalidArgumentException
@@ -92,13 +92,13 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
 
         // add slashes if they are not automatically added
         if (cRegistry::getConfigValue('simulate_magic_quotes') !== true) {
-            // backward compatiblity of passwords
+            // backward compatibility of passwords
             $password = addslashes($password);
             // avoid sql injection in query by username on cApiUserCollection select string
             $username = addslashes($username);
         }
 
-        $groupPerm = array();
+        $groupPerm = [];
 
         if ($password == '') {
             return false;
@@ -174,7 +174,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
      * "currentlogintime" and "lastlogintime" in mycontenido.
      *
      * @see cAuthHandlerAbstract::logSuccessfulAuth()
-     * 
+     *
      * @throws cDbException
      * @throws cException
      */
@@ -207,7 +207,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
             return;
         }
 
-        $idaction = $perm->getIDForAction('login');
+        $idaction = $perm->getIdForAction('login');
 
         $authInfo = $this->getAuthInfo();
         $uid = $authInfo['uid'];

--- a/contenido/classes/auth/class.auth.php
+++ b/contenido/classes/auth/class.auth.php
@@ -236,7 +236,7 @@ class cAuth {
     public function getUsername() {
         $authInfo = $this->getAuthInfo();
 
-        return $authInfo['uname'];
+        return isset($authInfo['uname']) ? $authInfo['uname'] : '';
     }
 
     /**
@@ -247,11 +247,11 @@ class cAuth {
     public function getPerms() {
         $authInfo = $this->getAuthInfo();
 
-        return $authInfo['perm'];
+        return isset($authInfo['perm']) ? $authInfo['perm'] : '';
     }
 
     /**
-     * Sets or refreshs the expiration of the authentication.
+     * Sets or refreshes the expiration of the authentication.
      *
      * @param int $expiration [optional]
      *         new expiration (optional, default: NULL = current time plus lifetime minutes)

--- a/contenido/classes/class.backend.php
+++ b/contenido/classes/class.backend.php
@@ -293,7 +293,7 @@ class cBackend {
         }
 
         $oldaction = $idaction;
-        $idaction = $perm->getIDForAction($idaction);
+        $idaction = $perm->getIdForAction($idaction);
 
         if ($idaction != '') {
             $oActionLogColl = new cApiActionlogCollection();

--- a/contenido/classes/class.rights.php
+++ b/contenido/classes/class.rights.php
@@ -15,7 +15,7 @@
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
 /**
- * This classs contains methods to handle rights.
+ * This class contains methods to handle rights.
  *
  * @package    Core
  * @subpackage Backend
@@ -44,7 +44,10 @@ class cRights
      */
     public static function copyRightsForElement($area, $iditem, $newiditem, $idlang = false)
     {
-        global $perm, $auth, $area_tree;
+        global $area_tree;
+
+        $perm = cRegistry::getPerm();
+        $auth = cRegistry::getAuth();
 
         if (!is_object($perm)) {
             return false;
@@ -54,7 +57,7 @@ class cRights
         }
 
         $oDestRightCol    = new cApiRightCollection();
-        $oSourceRighsColl = new cApiRightCollection();
+        $oSourceRightsColl = new cApiRightCollection();
         $whereUsers       = [];
         $whereAreaActions = [];
 
@@ -87,8 +90,8 @@ class cRights
             $sWhere .= ' AND idlang=' . (int)$idlang;
         }
 
-        $oSourceRighsColl->select($sWhere);
-        while (($oItem = $oSourceRighsColl->next()) !== false) {
+        $oSourceRightsColl->select($sWhere);
+        while (($oItem = $oSourceRightsColl->next()) !== false) {
             $rs = $oItem->toObject();
             $oDestRightCol->create(
                 $rs->user_id,
@@ -127,7 +130,11 @@ class cRights
      */
     public static function createRightsForElement($area, $iditem, $idlang = false)
     {
-        global $perm, $auth, $area_tree, $client;
+        global $area_tree;
+
+        $perm = cRegistry::getPerm();
+        $auth = cRegistry::getAuth();
+        $client = cRegistry::getClientId();
 
         if (!is_object($perm)) {
             return false;
@@ -137,7 +144,7 @@ class cRights
         }
 
         $oDestRightCol    = new cApiRightCollection();
-        $oSourceRighsColl = new cApiRightCollection();
+        $oSourceRightsColl = new cApiRightCollection();
         $whereUsers       = [];
         $rightsCache      = [];
 
@@ -162,8 +169,8 @@ class cRights
             $sWhere .= ' AND idlang=' . (int)$idlang;
         }
 
-        $oSourceRighsColl->select($sWhere);
-        while (($oItem = $oSourceRighsColl->next()) !== false) {
+        $oSourceRightsColl->select($sWhere);
+        while (($oItem = $oSourceRightsColl->next()) !== false) {
             $rs = $oItem->toObject();
 
             // concatenate a key to use it to prevent double entries
@@ -209,15 +216,16 @@ class cRights
      */
     public static function deleteRightsForElement($area, $iditem, $idlang = false)
     {
-        global $perm, $area_tree, $client;
+        global $area_tree;
+
+        $perm = cRegistry::getPerm();
+        $client = cRegistry::getClientId();
 
         // get all idarea values for $area
         $areaContainer = $area_tree[$perm->showareas($area)];
+        $areaContainer = implode(',', $areaContainer);
 
-        $sWhere = "idcat=" . (int)$iditem . " AND idclient=" . (int)$client . " AND idarea IN (" . implode(
-                ',',
-                $areaContainer
-            ) . ")";
+        $sWhere = "idcat=" . (int)$iditem . " AND idclient=" . (int)$client . " AND idarea IN (" . $areaContainer . ")";
         if ($idlang) {
             $sWhere .= " AND idlang=" . (int)$idlang;
         }
@@ -244,8 +252,10 @@ class cRights
      */
     public static function buildUserOrGroupPermsFromRequest($bAddUserToClient = false)
     {
-        global $auth, $client;
         global $msysadmin, $madmin, $mclient, $mlang;
+
+        $auth = cRegistry::getAuth();
+        $client = cRegistry::getClientId();
 
         // check and prevalidation
 
@@ -290,8 +300,7 @@ class cRights
         // Add user to the current client, if the current user isn't sysadmin and no client has been specified.
         // This avoids new accounts which are not accessible by the current user (client admin) anymore.
         if (count($aClient) == 0 && $bAddUserToClient) {
-            $aUserPerm = explode(',', $auth->auth['perm']);
-            if (!in_array('sysadmin', $aUserPerm)) {
+            if (!cPermission::checkSysadminPermission($auth->getPerms())) {
                 $aPerms[] = sprintf('client[%s]', $client);
             }
         }
@@ -319,9 +328,11 @@ class cRights
      */
     public static function saveRights()
     {
-        global $perm, $db, $userid;
+        global $db, $userid;
         global $rights_list, $rights_list_old, $rights_client, $rights_lang;
         global $aArticleRights, $aCategoryRights, $aTemplateRights;
+
+        $perm = cRegistry::getPerm();
 
         // If no checkbox is checked
         if (!is_array($rights_list)) {
@@ -329,65 +340,61 @@ class cRights
         }
 
         // Search all checks which are not in the new rights_list for deleting
-        $arraydel = array_diff(array_keys($rights_list_old), array_keys($rights_list));
+        $arrayDel = array_diff(array_keys($rights_list_old), array_keys($rights_list));
 
         // Search all checks which are not in the rights_list_old for saving
-        $arraysave = array_diff(array_keys($rights_list), array_keys($rights_list_old));
+        $arraySave = array_diff(array_keys($rights_list), array_keys($rights_list_old));
         $oAreaColl = new cApiAreaCollection();
 
-        if (is_array($arraydel)) {
-            foreach ($arraydel as $value) {
-                $data = explode('|', $value);
+        foreach ($arrayDel as $value) {
+            $data = explode('|', $value);
 
-                // Do not delete rights that does not display at this moment
-                if (!empty($_REQUEST['filter_rights'])) {
-                    if (($_REQUEST['filter_rights'] != 'article' && in_array($data[1], $aArticleRights))
-                        || ($_REQUEST['filter_rights'] != 'category' && in_array($data[1], $aCategoryRights))
-                        || ($_REQUEST['filter_rights'] != 'template' && in_array($data[1], $aTemplateRights))
-                    ) {
-                        continue;
-                    }
-
-                    if ($_REQUEST['filter_rights'] != 'other'
-                        && !in_array($data[1], array_merge($aArticleRights, $aCategoryRights, $aTemplateRights))
-                    ) {
-                        continue;
-                    }
+            // Do not delete rights that does not display at this moment
+            if (!empty($_REQUEST['filter_rights'])) {
+                if (($_REQUEST['filter_rights'] != 'article' && in_array($data[1], $aArticleRights))
+                    || ($_REQUEST['filter_rights'] != 'category' && in_array($data[1], $aCategoryRights))
+                    || ($_REQUEST['filter_rights'] != 'template' && in_array($data[1], $aTemplateRights))
+                ) {
+                    continue;
                 }
 
-                $data[0] = $oAreaColl->getAreaID($data[0]);
-                $data[1] = $perm->getIDForAction($data[1]);
-
-                $where      =
-                    "user_id = '" . $db->escape($userid) . "' AND idclient = " . (int)$rights_client . " AND idlang = "
-                    . (int)$rights_lang . " AND idarea = " . (int)$data[0] . " AND idcat = " . (int)$data[2]
-                    . " AND idaction = " . (int)$data[1] . " AND type = 0";
-                $oRightColl = new cApiRightCollection();
-                $oRightColl->deleteByWhereClause($where);
+                if ($_REQUEST['filter_rights'] != 'other'
+                    && !in_array($data[1], array_merge($aArticleRights, $aCategoryRights, $aTemplateRights))
+                ) {
+                    continue;
+                }
             }
+
+            $data[0] = $oAreaColl->getAreaId($data[0]);
+            $data[1] = $perm->getIdForAction($data[1]);
+
+            $where      =
+                "user_id = '" . $db->escape($userid) . "' AND idclient = " . (int)$rights_client . " AND idlang = "
+                . (int)$rights_lang . " AND idarea = " . (int)$data[0] . " AND idcat = " . (int)$data[2]
+                . " AND idaction = " . (int)$data[1] . " AND type = 0";
+            $oRightColl = new cApiRightCollection();
+            $oRightColl->deleteByWhereClause($where);
         }
 
         unset($data);
 
         // Search for all mentioned checkboxes
-        if (is_array($arraysave)) {
-            foreach ($arraysave as $value) {
-                // Explodes the key it consits areaid+actionid+itemid
-                $data = explode('|', $value);
+        foreach ($arraySave as $value) {
+            // Explodes the key it consists of areaid+actionid+itemid
+            $data = explode('|', $value);
 
-                // Since areas are stored in a numeric form in the rights table,
-                // we have to convert them from strings into numbers
-                $data[0] = $oAreaColl->getAreaID($data[0]);
-                $data[1] = $perm->getIDForAction($data[1]);
+            // Since areas are stored in a numeric form in the rights table,
+            // we have to convert them from strings into numbers
+            $data[0] = $oAreaColl->getAreaId($data[0]);
+            $data[1] = $perm->getIdForAction($data[1]);
 
-                if (!isset($data[1])) {
-                    $data[1] = 0;
-                }
-
-                // Insert new right
-                $oRightColl = new cApiRightCollection();
-                $oRightColl->create($userid, $data[0], $data[1], $data[2], $rights_client, $rights_lang, 0);
+            if (!isset($data[1])) {
+                $data[1] = 0;
             }
+
+            // Insert new right
+            $oRightColl = new cApiRightCollection();
+            $oRightColl->create($userid, $data[0], $data[1], $data[2], $rights_client, $rights_lang, 0);
         }
 
         $rights_list_old = $rights_list;
@@ -404,9 +411,11 @@ class cRights
      */
     public static function saveGroupRights()
     {
-        global $perm, $db, $groupid;
+        global $db, $groupid;
         global $rights_list, $rights_list_old, $rights_client, $rights_lang;
         global $aArticleRights, $aCategoryRights, $aTemplateRights;
+
+        $perm = cRegistry::getPerm();
 
         // If no checkbox is checked
         if (!is_array($rights_list)) {
@@ -414,66 +423,62 @@ class cRights
         }
 
         // Search all checks which are not in the new rights_list for deleting
-        $arraydel = array_diff(array_keys($rights_list_old), array_keys($rights_list));
+        $arrayDel = array_diff(array_keys($rights_list_old), array_keys($rights_list));
 
         // Search all checks which are not in the rights_list_old for saving
-        $arraysave = array_diff(array_keys($rights_list), array_keys($rights_list_old));
+        $arraySave = array_diff(array_keys($rights_list), array_keys($rights_list_old));
 
         $oAreaColl = new cApiAreaCollection();
 
-        if (is_array($arraydel)) {
-            foreach ($arraydel as $value) {
-                $data = explode('|', $value);
+        foreach ($arrayDel as $value) {
+            $data = explode('|', $value);
 
-                // Do not delete grouprights that does not display at this moment
-                if (!empty($_REQUEST['filter_rights'])) {
-                    if (($_REQUEST['filter_rights'] != 'article' && in_array($data[1], $aArticleRights))
-                        || ($_REQUEST['filter_rights'] != 'category' && in_array($data[1], $aCategoryRights))
-                        || ($_REQUEST['filter_rights'] != 'template' && in_array($data[1], $aTemplateRights))
-                    ) {
-                        continue;
-                    }
-
-                    if ($_REQUEST['filter_rights'] != 'other'
-                        && !in_array($data[1], array_merge($aArticleRights, $aCategoryRights, $aTemplateRights))
-                    ) {
-                        continue;
-                    }
+            // Do not delete grouprights that does not display at this moment
+            if (!empty($_REQUEST['filter_rights'])) {
+                if (($_REQUEST['filter_rights'] != 'article' && in_array($data[1], $aArticleRights))
+                    || ($_REQUEST['filter_rights'] != 'category' && in_array($data[1], $aCategoryRights))
+                    || ($_REQUEST['filter_rights'] != 'template' && in_array($data[1], $aTemplateRights))
+                ) {
+                    continue;
                 }
 
-                $data[0] = $oAreaColl->getAreaID($data[0]);
-                $data[1] = $perm->getIDForAction($data[1]);
-
-                $where      =
-                    "user_id = '" . $db->escape($groupid) . "' AND idclient = " . (int)$rights_client . " AND idlang = "
-                    . (int)$rights_lang . " AND idarea = " . (int)$data[0] . " AND idcat = " . (int)$data[2]
-                    . " AND idaction = " . (int)$data[1] . " AND type = 1";
-                $oRightColl = new cApiRightCollection();
-                $oRightColl->deleteByWhereClause($where);
+                if ($_REQUEST['filter_rights'] != 'other'
+                    && !in_array($data[1], array_merge($aArticleRights, $aCategoryRights, $aTemplateRights))
+                ) {
+                    continue;
+                }
             }
+
+            $data[0] = $oAreaColl->getAreaId($data[0]);
+            $data[1] = $perm->getIdForAction($data[1]);
+
+            $where      =
+                "user_id = '" . $db->escape($groupid) . "' AND idclient = " . (int)$rights_client . " AND idlang = "
+                . (int)$rights_lang . " AND idarea = " . (int)$data[0] . " AND idcat = " . (int)$data[2]
+                . " AND idaction = " . (int)$data[1] . " AND type = 1";
+            $oRightColl = new cApiRightCollection();
+            $oRightColl->deleteByWhereClause($where);
         }
 
         unset($data);
 
         // Search for all mentioned checkboxes
-        if (is_array($arraysave)) {
-            foreach ($arraysave as $value) {
-                // Explodes the key it consits areaid+actionid+itemid
-                $data = explode('|', $value);
+        foreach ($arraySave as $value) {
+            // Explodes the key it consists of areaid+actionid+itemid
+            $data = explode('|', $value);
 
-                // Since areas are stored in a numeric form in the rights table,
-                // we have to convert them from strings into numbers
-                $data[0] = $oAreaColl->getAreaID($data[0]);
-                $data[1] = $perm->getIDForAction($data[1]);
+            // Since areas are stored in a numeric form in the rights table,
+            // we have to convert them from strings into numbers
+            $data[0] = $oAreaColl->getAreaId($data[0]);
+            $data[1] = $perm->getIdForAction($data[1]);
 
-                if (!isset($data[1])) {
-                    $data[1] = 0;
-                }
-
-                // Insert new right
-                $oRightColl = new cApiRightCollection();
-                $oRightColl->create($groupid, $data[0], $data[1], $data[2], $rights_client, $rights_lang, 1);
+            if (!isset($data[1])) {
+                $data[1] = 0;
             }
+
+            // Insert new right
+            $oRightColl = new cApiRightCollection();
+            $oRightColl->create($groupid, $data[0], $data[1], $data[2], $rights_client, $rights_lang, 1);
         }
 
         $rights_list_old = $rights_list;

--- a/contenido/classes/contenido/class.area.php
+++ b/contenido/classes/contenido/class.area.php
@@ -36,8 +36,8 @@ class cApiAreaCollection extends ItemCollection {
      *
      * @param string     $name
      *                             Name
-     * @param string|int $parentid [optional]
-     *                             Parent id as astring or number
+     * @param string|int $parentId [optional]
+     *                             Parent id as a string or number
      * @param int        $relevant [optional]
      *                             0 or 1
      * @param int        $online   [optional]
@@ -51,12 +51,12 @@ class cApiAreaCollection extends ItemCollection {
      * @throws cException
      * @throws cInvalidArgumentException
      */
-    public function create($name, $parentid = 0, $relevant = 1, $online = 1, $menuless = 0) {
-        $parentid = (is_string($parentid)) ? $this->escape($parentid) : (int) $parentid;
+    public function create($name, $parentId = 0, $relevant = 1, $online = 1, $menuless = 0) {
+        $parentId = (is_string($parentId)) ? $this->escape($parentId) : (int) $parentId;
 
         $item = $this->createNewItem();
 
-        $item->set('parent_id', $parentid);
+        $item->set('parent_id', $parentId);
         $item->set('name', $name);
         $item->set('relevant', $relevant);
         $item->set('online', $online);
@@ -78,7 +78,7 @@ class cApiAreaCollection extends ItemCollection {
      *
      * @throws cDbException
      */
-    public function getParentAreaID($area) {
+    public function getParentAreaId($area) {
         if (is_numeric($area)) {
             $sql = "SELECT b.name FROM `%s` AS a, `%s` AS b WHERE a.idarea = %d AND b.name = a.parent_id";
         } else {
@@ -103,12 +103,48 @@ class cApiAreaCollection extends ItemCollection {
         $sql = "SELECT idarea FROM `%s` AS a WHERE a.name = '%s' OR a.parent_id = '%s' ORDER BY idarea";
         $this->db->query($sql, $this->table, $nameOrId, $nameOrId);
 
-        $ids = array();
+        $ids = [];
         while ($this->db->nextRecord()) {
             $ids[] = $this->db->f('idarea');
         }
 
         return $ids;
+    }
+
+    /**
+     * Returns the area name by area id.
+     *
+     * This function is similar to {@see cApiAreaCollection::getAreaName()},
+     * but it uses direct SQL instead a cApiArea instance.
+     *
+     * @param int $areaId The area id
+     * @return string
+     * @throws cDbException
+     */
+    public function getNameByAreaId($areaId) {
+        $sql = "SELECT `name` FROM `%s` WHERE `idarea` = %d";
+        $this->db->query($sql, $this->table, $areaId);
+        return ($this->db->nextRecord()) ? $this->db->f('name') : '';
+    }
+
+    /**
+     * Returns area ids of areas by parent id and area id.
+     *
+     * @param string|int $parentId Parent id as a string or number
+     * @param int $areaId The area id
+     * @return array
+     * @throws cDbException
+     */
+    public function getAreaIdsByParentIdOrAreaId($parentId, $areaId) {
+        $sql = "SELECT `idarea` FROM `%s` WHERE `parent_id` = '%s' OR `idarea` = %d";
+        $this->db->query($sql, $this->table, $parentId, $areaId);
+
+        $areaIds = [];
+        while ($this->db->nextRecord()) {
+            $areaIds[] = $this->db->f('idarea');
+        }
+
+        return $areaIds;
     }
 
     /**
@@ -121,17 +157,16 @@ class cApiAreaCollection extends ItemCollection {
      * @throws cException
      */
     public function getAvailableAreas() {
-        $aClients = array();
-
         $this->select();
 
+        $aAreas = [];
         while (($oItem = $this->next()) !== false) {
-            $aAreas[$oItem->get('idarea')] = array(
+            $aAreas[$oItem->get('idarea')] = [
                 'name' => $oItem->get('name')
-            );
+            ];
         }
 
-        return ($aAreas);
+        return $aAreas;
     }
 
     /**
@@ -157,7 +192,7 @@ class cApiAreaCollection extends ItemCollection {
      * @throws cDbException
      * @throws cException
      */
-    public function getAreaID($area) {
+    public function getAreaId($area) {
         // if area name is numeric (legacy areas)
         if (is_numeric($area)) {
             return $area;

--- a/contenido/classes/genericdb/class.item.base.abstract.php
+++ b/contenido/classes/genericdb/class.item.base.abstract.php
@@ -21,8 +21,8 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  * collections.
  *
  * NOTE:
- * Because of required downwards compatibilitiy all protected/private member
- * variables or methods don't have an leading underscore.
+ * Because of required downwards compatibility all protected/private member
+ * variables or methods don't have a leading underscore.
  *
  * @package Core
  * @subpackage GenericDB
@@ -108,7 +108,7 @@ abstract class cItemBaseAbstract extends cGenericDb {
     protected $_loaded = false;
 
     /**
-     * Storage of the last occured error
+     * Storage of the last occurred error
      *
      * @var string
      */
@@ -255,6 +255,23 @@ abstract class cItemBaseAbstract extends cGenericDb {
     }
 
     /**
+     * Prepares the statement for execution and returns it back.
+     * The function can be called with a statement and replacement parameters,
+     * see {@see cDbDriverHandler::prepare()} for more details.
+     *
+     * @param mixed ... Multiple parameters where the first is the statement and the further ones the replacements.
+     *     See {@see cDbDriverHandler::prepare()} for more details.
+     * @return string
+     * @throws cDbException
+     */
+    public function prepare() {
+        $arguments = func_get_args();
+        $statement = count($arguments) ? array_shift($arguments) : '';
+
+        return $this->db->prepare($statement, $arguments);
+    }
+
+    /**
      * Set the primary key name for class
      * The name must always match the primary key name in database
      *
@@ -279,7 +296,7 @@ abstract class cItemBaseAbstract extends cGenericDb {
 
     /**
      * Returns properties instance, instantiates it if not done before.
-     * NOTE: This funtion changes always the client variable of property
+     * NOTE: This function changes always the client variable of property
      * collection instance.
      *
      * @param int $idclient [optional]

--- a/contenido/includes/frontend/include.front_content.php
+++ b/contenido/includes/frontend/include.front_content.php
@@ -401,7 +401,7 @@ if ($contenido) {
     $locked = $oArtLang->get('locked');
     if ($locked == 1) {
         // admin can edit article despite its locked status
-        $isAdmin = $perm::checkAdminPermission($auth->getPerms());
+        $isAdmin = cPermission::checkAdminPermission($auth->getPerms());
         if (false === $isAdmin) {
             $notification    = new cGuiNotification();
             $modErrorMessage = i18n('This article is currently frozen and can not be edited!');

--- a/contenido/includes/frontend/include.front_content.php
+++ b/contenido/includes/frontend/include.front_content.php
@@ -401,12 +401,8 @@ if ($contenido) {
     $locked = $oArtLang->get('locked');
     if ($locked == 1) {
         // admin can edit article despite its locked status
-        $aAuthPerms = explode(',', cRegistry::getAuth()->auth['perm']);
-        $admin      = false;
-        if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-            $admin = true;
-        }
-        if (false === $admin) {
+        $isAdmin = $perm::checkAdminPermission($auth->getPerms());
+        if (false === $isAdmin) {
             $notification    = new cGuiNotification();
             $modErrorMessage = i18n('This article is currently frozen and can not be edited!');
             $inUse             = true;

--- a/contenido/includes/functions.con.php
+++ b/contenido/includes/functions.con.php
@@ -284,25 +284,23 @@ function conEditFirstTime(
  * @throws cInvalidArgumentException
  */
 function conEditArt($idcat, $idcatnew, $idart, $isstart, $idtpl, $idartlang, $idlang, $title, $summary, $artspec, $created, $lastmodified, $author, $online, $datestart, $dateend, $published, $artsort, $keyart = 0, $searchable = 1, $sitemapprio = -1, $changefreq = 'nothing') {
-    global $client, $lang, $redirect, $redirect_url, $external_redirect, $perm;
+    global $client, $lang, $redirect, $redirect_url, $external_redirect;
     global $urlname, $page_title;
     global $time_move_cat, $time_target_cat;
     // Used to indicate if the moved article should be online
     global $time_online_move;
     global $timemgmt;
-    // CON-2134 check admin permission
-    $auth = cRegistry::getAuth();
-    $aAuthPerms = explode(',', $auth->auth['perm']);
 
-    $admin = false;
-    if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-        $admin = true;
-    }
+    $perm = cRegistry::getPerm();
+
+    // CON-2134 check admin permission
+    $isAdmin = $perm::checkAdminPermission(cRegistry::getAuth()->getPerms());
+
     $oArtLang = new cApiArticleLanguage($idartlang);
     $locked = (int) $oArtLang->get('locked');
 
-    // abort editing if article is locked and user user no admin
-    if (1 === $locked && false === $admin) {
+    // abort editing if article is locked and user is no admin
+    if (1 === $locked && false === $isAdmin) {
         return $idart;
     }
 
@@ -624,7 +622,8 @@ function conMakeArticleIndex($idartlang, $idart) {
         }
         // get first idcat by idart
         $coll = new cApiCategoryArticleCollection();
-        $idcat = array_shift($coll->getCategoryIdsByArticleId($idart));
+        $categoryIds = $coll->getCategoryIdsByArticleId($idart);
+        $idcat = array_shift($categoryIds);
         // get idcatlang by idcat & idlang
         $categoryLanguage = new cApiCategoryLanguage();
         $categoryLanguage->loadByCategoryIdAndLanguageId($idcat, $idlang);

--- a/contenido/includes/functions.con.php
+++ b/contenido/includes/functions.con.php
@@ -294,7 +294,7 @@ function conEditArt($idcat, $idcatnew, $idart, $isstart, $idtpl, $idartlang, $id
     $perm = cRegistry::getPerm();
 
     // CON-2134 check admin permission
-    $isAdmin = $perm::checkAdminPermission(cRegistry::getAuth()->getPerms());
+    $isAdmin = cPermission::checkAdminPermission(cRegistry::getAuth()->getPerms());
 
     $oArtLang = new cApiArticleLanguage($idartlang);
     $locked = (int) $oArtLang->get('locked');

--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -212,7 +212,7 @@ function displayDatetime($timestamp = "", $date = false, $time = false) {
  * @throws cDbException
  * @throws cException
  */
-function getIDForArea($area) {
+function getIdForArea($area) {
     if (!is_numeric($area)) {
         $oArea = new cApiArea();
         if ($oArea->loadBy('name', $area)) {
@@ -234,7 +234,7 @@ function getIDForArea($area) {
  */
 function getParentAreaId($area) {
     $oAreaColl = new cApiAreaCollection();
-    return $oAreaColl->getParentAreaID($area);
+    return $oAreaColl->getParentAreaId($area);
 }
 
 /**
@@ -339,7 +339,7 @@ function backToMainArea($send) {
 
         // Get main area
         $oAreaColl = new cApiAreaCollection();
-        $parent = $oAreaColl->getParentAreaID($area);
+        $parent = $oAreaColl->getParentAreaId($area);
 
         // Create url string
         $url_str = 'main.php?' . 'area=' . $parent . '&' . 'idcat=' . $idcat . '&' . 'idart=' . $idart . '&'

--- a/contenido/includes/include.con_art_overview.php
+++ b/contenido/includes/include.con_art_overview.php
@@ -535,12 +535,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
             }
 
             // CON-2137 check admin permission
-            $aAuthPerms = explode(',', $auth->auth['perm']);
-
-            $admin = false;
-            if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-                $admin = true;
-            }
+            $isAdmin = $perm::checkAdminPermission($auth->getPerms());
 
             // Make Startarticle button
             $imgsrc = "isstart";
@@ -559,7 +554,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
 
             $imgsrc .= '.gif';
 
-            if ($idlang == $lang && ($perm->have_perm_area_action('con', 'con_makestart') || $perm->have_perm_area_action_item('con', 'con_makestart', $idcat)) && $idcat != 0 && ((int) $locked === 0 || $admin)) {
+            if ($idlang == $lang && ($perm->have_perm_area_action('con', 'con_makestart') || $perm->have_perm_area_action_item('con', 'con_makestart', $idcat)) && $idcat != 0 && ((int) $locked === 0 || $isAdmin)) {
                 if ($is_start == false) {
                     $tmp_link = '<a href="' . $sess->url("main.php?area=con&amp;idcat=$idcat&action=con_makestart&idcatart=$idcatart&frame=4&is_start=1&next=$next") . '" title="' . i18n("Flag as start article") . '"><img class="vAlignMiddle tableElement" src="images/' . $imgsrc . '" title="' . i18n("Flag as start article") . '" alt="' . i18n("Flag as start article") . '"></a>';
                 } else {
@@ -580,7 +575,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
             $tmp_start = $tmp_link;
 
             // Make copy button
-            if (($perm->have_perm_area_action('con', 'con_duplicate') || $perm->have_perm_area_action_item('con', 'con_duplicate', $idcat)) && $idcat != 0 && ((int) $locked === 0 || $admin )) {
+            if (($perm->have_perm_area_action('con', 'con_duplicate') || $perm->have_perm_area_action_item('con', 'con_duplicate', $idcat)) && $idcat != 0 && ((int) $locked === 0 || $isAdmin )) {
                 $imgsrc = "but_copy.gif";
                 // add count_duplicate param to identify if the duplicate action
                 // is called from click or back button.
@@ -607,13 +602,13 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
 
             // Make On-/Offline button
             if ($online) {
-                if (($perm->have_perm_area_action('con', 'con_makeonline') || $perm->have_perm_area_action_item('con', 'con_makeonline', $idcat)) && ($idcat != 0) && ((int) $locked === 0 || $admin)) {
+                if (($perm->have_perm_area_action('con', 'con_makeonline') || $perm->have_perm_area_action_item('con', 'con_makeonline', $idcat)) && ($idcat != 0) && ((int) $locked === 0 || $isAdmin)) {
                     $tmp_online = '<a href="' . $sess->url("main.php?area=con&idcat=$idcat&action=con_makeonline&frame=4&idart=$idart&next=$next") . '" title="' . i18n("Make offline") . '"><img class="vAlignMiddle tableElement" src="images/online.gif" title="' . i18n("Make offline") . '" alt="' . i18n("Make offline") . '"></a>';
                 } else {
                     $tmp_online = '<img class="borderless vAlignMiddle tableElement" src="images/online.gif" title="' . i18n("Article is online") . '" alt="' . i18n("Article is online") . '">';
                 }
             } else {
-                if (($perm->have_perm_area_action('con', 'con_makeonline') || $perm->have_perm_area_action_item('con', 'con_makeonline', $idcat)) && ($idcat != 0) && ((int) $locked === 0 || $admin)) {
+                if (($perm->have_perm_area_action('con', 'con_makeonline') || $perm->have_perm_area_action_item('con', 'con_makeonline', $idcat)) && ($idcat != 0) && ((int) $locked === 0 || $isAdmin)) {
                     $tmp_online = '<a href="' . $sess->url("main.php?area=con&idcat=$idcat&action=con_makeonline&frame=4&idart=$idart&next=$next") . '" title="' . i18n("Make online") . '"><img class="vAlignMiddle tableElement" src="images/offline.gif" title="' . i18n("Make online") . '" alt="' . i18n("Make online") . '"></a>';
                 } else {
                     $tmp_online = '<img class="borderless vAlignMiddle tableElement" src="images/offline.gif" title="' . i18n("Article is offline") . '" alt="' . i18n("Article is offline") . '">';
@@ -627,7 +622,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
             }
 
             // Delete button
-            if (($perm->have_perm_area_action('con', 'con_deleteart') || $perm->have_perm_area_action_item('con', 'con_deleteart', $idcat)) && $inUse == false && ((int) $locked === 0  || $admin)) {
+            if (($perm->have_perm_area_action('con', 'con_deleteart') || $perm->have_perm_area_action_item('con', 'con_deleteart', $idcat)) && $inUse == false && ((int) $locked === 0  || $isAdmin)) {
                 $tmp_title = $title;
                 if (cString::getStringLength($tmp_title) > 30) {
                     $tmp_title = cString::getPartOfString($tmp_title, 0, 27) . "...";

--- a/contenido/includes/include.con_art_overview.php
+++ b/contenido/includes/include.con_art_overview.php
@@ -535,7 +535,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
             }
 
             // CON-2137 check admin permission
-            $isAdmin = $perm::checkAdminPermission($auth->getPerms());
+            $isAdmin = cPermission::checkAdminPermission($auth->getPerms());
 
             // Make Startarticle button
             $imgsrc = "isstart";

--- a/contenido/includes/include.con_edit_form.php
+++ b/contenido/includes/include.con_edit_form.php
@@ -42,7 +42,7 @@ $page = new cGuiPage("con_edit_form", "", "con_editart");
 $tpl = null;
 
 // Admin rights
-$isAdmin = $perm::checkAdminPermission(cRegistry::getAuth()->getPerms());
+$isAdmin = cPermission::checkAdminPermission(cRegistry::getAuth()->getPerms());
 
 if (isset($idart)) {
     if (!isset($idartlang) || 0 == $idartlang) {

--- a/contenido/includes/include.con_edit_form.php
+++ b/contenido/includes/include.con_edit_form.php
@@ -20,21 +20,29 @@ cInclude("includes", "functions.str.php");
 cInclude("includes", "functions.pathresolver.php");
 
 // ugly globals that are used in this script
-global $tpl, $cfg, $db, $perm, $sess, $selectedArticleId;
-global $frame, $area, $action, $contenido, $notification;
-global $client, $lang, $belang, $lngAct, $auth;
-global $idcat, $idart, $idcatlang, $idartlang, $idcatart, $idtpl;
+global $tpl, $db, $selectedArticleId, $contenido, $notification, $lngAct, $idcatart, $idtpl;
 global $tplinputchanged, $idcatnew, $newart, $syncoptions, $tmp_notification, $bNoArticle, $artLangVersion, $classarea;
+
+$perm = cRegistry::getPerm();
+$sess = cRegistry::getSession();
+$area = cRegistry::getArea();
+$action = cRegistry::getAction();
+$client = cRegistry::getClientId();
+$cfg = cRegistry::getConfig();
+$frame = cRegistry::getFrame();
+$auth = cRegistry::getAuth();
+$lang = cRegistry::getLanguageId();
+$belang = cRegistry::getBackendLanguage();
+$idart = cRegistry::getArticleId();
+$idcat = cRegistry::getCategoryId();
+$idcatlang = cRegistry::getCategoryLanguageId();
+$idartlang = cRegistry::getArticleLanguageId();
 
 $page = new cGuiPage("con_edit_form", "", "con_editart");
 $tpl = null;
 
 // Admin rights
-$aAuthPerms = explode(',', cRegistry::getAuth()->auth['perm']);
-$admin = false;
-if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-	$admin = true;
-}
+$isAdmin = $perm::checkAdminPermission(cRegistry::getAuth()->getPerms());
 
 if (isset($idart)) {
     if (!isset($idartlang) || 0 == $idartlang) {
@@ -630,7 +638,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
         // Remove all own marks
         $col->removeSessionMarks($sess->id);
 
-        if (false === $admin) {
+        if (false === $isAdmin) {
 
 	        if ((($obj = $col->checkMark("article", $tmp_idartlang)) === false || $obj->get("userid") == $auth->auth['uid']) && $tmp_locked != 1) {
 	            $col->markInUse("article", $tmp_idartlang, $sess->id, $auth->auth["uid"]);

--- a/contenido/includes/include.con_meta_form.php
+++ b/contenido/includes/include.con_meta_form.php
@@ -41,7 +41,7 @@ $idcatlang = cRegistry::getCategoryLanguageId();
 $tpl->reset();
 
 // Admin rights
-$isAdmin = $perm::checkAdminPermission($auth->getPerms());
+$isAdmin = cPermission::checkAdminPermission($auth->getPerms());
 
 // Check permissions
 if (!$perm->have_perm_area_action($area, 'con_meta_edit') && !$perm->have_perm_area_action_item($area, 'con_meta_edit', $idcat)) {
@@ -349,7 +349,7 @@ foreach ($availableTags as $key => $value) {
 
     if ($versioning->getState() == 'simple' && $articleType == 'current'
             || $versioning->getState() == 'advanced' && $articleType == 'editable'
-            || $versioning->getState() == 'disabled' && ($art->getField('locked') != 1 || $perm::checkSysadminPermission($auth->getPerms()))) {
+            || $versioning->getState() == 'disabled' && ($art->getField('locked') != 1 || cPermission::checkSysadminPermission($auth->getPerms()))) {
         $tpl->set('d', 'CURSOR', 'pointer');
         $tpl->set('d', 'DELETE_META',
             "Con.showConfirmation('" .
@@ -665,7 +665,7 @@ while ($db->nextRecord()) {
 }
 
 // accessible by the current user (sysadmin client admin) anymore.
-if ($perm::checkSysadminPermission($auth->getPerms())) {
+if (cPermission::checkSysadminPermission($auth->getPerms())) {
     // disable/grey out button if a non-editable version is selected
     if ($versioning->getState() == 'simple' && $articleType != 'current'
             || $versioning->getState() == 'advanced' && $articleType != 'editable') {

--- a/contenido/includes/include.con_meta_form.php
+++ b/contenido/includes/include.con_meta_form.php
@@ -41,11 +41,7 @@ $idcatlang = cRegistry::getCategoryLanguageId();
 $tpl->reset();
 
 // Admin rights
-$aAuthPerms = explode(',', cRegistry::getAuth()->auth['perm']);
-$admin = false;
-if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-	$admin = true;
-}
+$isAdmin = $perm::checkAdminPermission($auth->getPerms());
 
 // Check permissions
 if (!$perm->have_perm_area_action($area, 'con_meta_edit') && !$perm->have_perm_area_action_item($area, 'con_meta_edit', $idcat)) {
@@ -176,7 +172,7 @@ if ($art->getField('created')) {
         $tpl->set("s", "REASON", sprintf(i18n('Article is in use by %s (%s)'), $inUseUser, $inUseUserRealName));
     }
 
-    if ($art->getField('locked') == 1 && false === $admin) {
+    if ($art->getField('locked') == 1 && false === $isAdmin) {
         $disabled = 'disabled="disabled"';
         $tpl->set('s', 'DISABLED', ' ' . $disabled);
         $notifications[] = $notification->returnNotification('warning', i18n('This article is currently frozen and can not be edited!'));
@@ -353,7 +349,7 @@ foreach ($availableTags as $key => $value) {
 
     if ($versioning->getState() == 'simple' && $articleType == 'current'
             || $versioning->getState() == 'advanced' && $articleType == 'editable'
-            || $versioning->getState() == 'disabled' && ($art->getField('locked') != 1 || in_array('sysadmin', $aAuthPerms))) {
+            || $versioning->getState() == 'disabled' && ($art->getField('locked') != 1 || $perm::checkSysadminPermission($auth->getPerms()))) {
         $tpl->set('d', 'CURSOR', 'pointer');
         $tpl->set('d', 'DELETE_META',
             "Con.showConfirmation('" .
@@ -669,7 +665,7 @@ while ($db->nextRecord()) {
 }
 
 // accessible by the current user (sysadmin client admin) anymore.
-if (in_array('sysadmin', $aAuthPerms)) {
+if ($perm::checkSysadminPermission($auth->getPerms())) {
     // disable/grey out button if a non-editable version is selected
     if ($versioning->getState() == 'simple' && $articleType != 'current'
             || $versioning->getState() == 'advanced' && $articleType != 'editable') {

--- a/contenido/includes/include.mycontenido_lastarticles.php
+++ b/contenido/includes/include.mycontenido_lastarticles.php
@@ -16,6 +16,16 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
 
 cInclude("includes", "functions.con.php");
 
+global $tpl, $db;
+
+$cfg = cRegistry::getConfig();
+$perm = cRegistry::getPerm();
+$auth = cRegistry::getAuth();
+$lang = cRegistry::getLanguageId();
+$client = cRegistry::getClientId();
+$sess = cRegistry::getSession();
+$frame = cRegistry::getFrame();
+
 $sql = "SELECT
             logtimestamp
         FROM
@@ -31,7 +41,7 @@ $db->nextRecord();
 
 $lastlogin = $db->f("logtimestamp");
 
-$idaction = $perm->getIDForAction("con_editart");
+$idaction = $perm->getIdForAction("con_editart");
 
 $sql = "SELECT
             a.idart AS idart,

--- a/contenido/includes/include.tplcfg_edit_form.php
+++ b/contenido/includes/include.tplcfg_edit_form.php
@@ -103,7 +103,7 @@ if ($idart) {
         $artlang = new cApiArticleLanguage($idartlang);
 
         // check admin rights
-        $isAdmin = $perm::checkAdminPermission($auth->getPerms());
+        $isAdmin = cPermission::checkAdminPermission($auth->getPerms());
 
         if ($artlang->isLoaded()) {
             if(!$idtpl && $idcat && $idart && (int) $artlang->get('locked') === 1) {

--- a/contenido/includes/include.tplcfg_edit_form.php
+++ b/contenido/includes/include.tplcfg_edit_form.php
@@ -16,9 +16,18 @@
 
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
-global $db, $notification, $tpl, $auth, $perm, $cfg, $sess, $client, $area, $frame, $idcat, $idart, $idtpl, $lang, $idtplcfg, $syncoptions;
+global $db, $notification, $tpl, $idcat, $idart, $idtpl, $idtplcfg, $syncoptions;
 
 cInclude('includes', 'functions.pathresolver.php');
+
+$auth = cRegistry::getAuth();
+$sess = cRegistry::getSession();
+$perm = cRegistry::getPerm();
+$area = cRegistry::getArea();
+$frame = cRegistry::getFrame();
+$cfg = cRegistry::getConfig();
+$client = cRegistry::getClientId();
+$lang = cRegistry::getLanguageId();
 
 $message = '';
 $description = '';
@@ -86,25 +95,22 @@ if (!isset($db3) || !is_object($db3)) {
 
 $tpl->reset();
 
+$isAdmin = false;
+
 if ($idart) {
     if ($perm->have_perm_area_action('con', 'con_tplcfg_edit') || $perm->have_perm_area_action_item('con', 'con_tplcfg_edit', $idcat)) {
 
         $artlang = new cApiArticleLanguage($idartlang);
 
         // check admin rights
-        $aAuthPerms = explode(',', $auth->auth['perm']);
-
-        $admin = false;
-        if (count(preg_grep("/admin.*/", $aAuthPerms)) > 0) {
-            $admin = true;
-        }
+        $isAdmin = $perm::checkAdminPermission($auth->getPerms());
 
         if ($artlang->isLoaded()) {
             if(!$idtpl && $idcat && $idart && (int) $artlang->get('locked') === 1) {
                 $inUse    = true;
-                $disabled = ($admin === false)? 'disabled="disabled"' : '';
+                $disabled = ($isAdmin === false)? 'disabled="disabled"' : '';
                 // display notification if article configuration can not be edited
-                if (false === $admin) {
+                if (false === $isAdmin) {
                     $message = i18n('This article is currently frozen and can not be edited!');
                     $notificationMsg .= $notification->returnNotification('warning', $message) . '<br>';
                 }
@@ -138,7 +144,7 @@ if ($idart) {
 
             if ($db->f('locked') == 1) {
                 $inUse = true;
-                $disabled = ($admin)? '': 'disabled="disabled"';
+                $disabled = ($isAdmin)? '': 'disabled="disabled"';
                 if ($configLocked === false){
                     $message = i18n('This article is currently frozen and can not be edited!');
                     $notificationMsg .= $notification->returnNotification('warning', $message) . '<br>';
@@ -276,7 +282,7 @@ $tpl2->set('s', 'CLASS', 'text_medium');
 
 // CON-2157 fix categorie page has no article
 if (!$perm->have_perm_area_action_item('con', 'con_changetemplate', $idcat) || is_object($artlang) && $artlang->get('locked') === 1 ) {
-    $disabled2 = ($admin) ? '' : 'disabled="disabled"' ;
+    $disabled2 = ($isAdmin) ? '' : 'disabled="disabled"' ;
 } else {
     $disabled2 = '';
 }

--- a/test/contenido/classes/cPermissionTest.php
+++ b/test/contenido/classes/cPermissionTest.php
@@ -1,0 +1,323 @@
+<?php
+
+/**
+ * This file contains tests for Contenido cPermission.
+ *
+ * @package          Testing
+ * @subpackage       Test_Registry
+ * @author           Murat Purc <murat@purc.de>
+ * @copyright        four for business AG <www.4fb.de>
+ * @license          http://www.contenido.org/license/LIZENZ.txt
+ * @link             http://www.4fb.de
+ * @link             http://www.contenido.org
+ */
+
+
+/**
+ * Class to test cPermission.
+ *
+ * TODO Implement other unit tests for cPermission.
+ *
+ * @package          Testing
+ * @subpackage       Test_Permission
+ */
+class cPermissionTest extends cTestingTestCase
+{
+
+    /**
+     * Test cPermission#permissionToArray.
+     *
+     * @return void
+     */
+    public function testPermissionToArray()
+    {
+        $result = cPermission::permissionToArray(null);
+        $this->assertEquals([], $result);
+
+        $result = cPermission::permissionToArray(2);
+        $this->assertEquals([], $result);
+
+        $result = cPermission::permissionToArray('');
+        $this->assertEquals([], $result);
+
+        $result = cPermission::permissionToArray('lang[1]');
+        $this->assertEquals(['lang[1]'], $result);
+
+        $result = cPermission::permissionToArray(['lang[1]']);
+        $this->assertEquals(['lang[1]'], $result);
+
+        $result = cPermission::permissionToArray('lang[1],client[2]');
+        $this->assertEquals(['lang[1]', 'client[2]'], $result);
+
+        $result = cPermission::permissionToArray(['lang[1]', 'client[2]']);
+        $this->assertEquals(['lang[1]', 'client[2]'], $result);
+    }
+
+    /**
+     * Test cPermission#checkLanguagePermission.
+     *
+     * @return void
+     */
+    public function testCheckLanguagePermission()
+    {
+        $languageId = 1;
+
+        $result = cPermission::checkLanguagePermission($languageId, '');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, []);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, 'lang[2]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, ['lang[2]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, 'lang[2],lang[3]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, ['lang[2]', 'lang[3]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, 'lang[1]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkLanguagePermission($languageId, ['lang[1]']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#checkClientPermission.
+     *
+     * @return void
+     */
+    public function testCheckClientPermission()
+    {
+        $clientId = 1;
+
+        $result = cPermission::checkClientPermission($clientId, '');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, []);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, 'client[2]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, ['client[2]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, 'client[2],client[3]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, ['client[2]', 'client[3]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientPermission($clientId, 'client[1]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkClientPermission($clientId, ['client[1]']);
+        $this->assertEquals(true, $result);
+    }
+
+
+    /**
+     * Test cPermission#checkClientAndLanguagePermission.
+     *
+     * @return void
+     */
+    public function testCheckClientAndLanguagePermission()
+    {
+        $clientId = 1;
+        $languageId = 2;
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, '');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, []);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, 'client[2],lang[4]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, ['client[2]', 'lang[4]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, 'client[1],lang[4]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, ['client[1]', 'client[3]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, 'client[1],lang[2]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkClientAndLanguagePermission($clientId, $languageId, ['client[1]', 'lang[2]']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#checkClientAdminPermission.
+     *
+     * @return void
+     */
+    public function testCheckClientAdminPermission()
+    {
+        $clientId = 1;
+
+        $result = cPermission::checkClientAdminPermission($clientId, '');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAdminPermission($clientId, []);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAdminPermission($clientId, 'admin[2]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAdminPermission($clientId, ['admin[2]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkClientAdminPermission($clientId, 'admin[1]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkClientAdminPermission($clientId, ['admin[1]']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#checkAdminPermission.
+     *
+     * @return void
+     */
+    public function testCheckAdminPermission()
+    {
+        $result = cPermission::checkAdminPermission('');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkAdminPermission([]);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkAdminPermission('sysadmin', true);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkAdminPermission(['sysadmin'], true);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkAdminPermission('admin[1]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkAdminPermission(['admin[1]']);
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkAdminPermission('sysadmin');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkAdminPermission(['sysadmin']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#checkSysadminPermission.
+     *
+     * @return void
+     */
+    public function testCheckSysadminPermission()
+    {
+        $result = cPermission::checkSysadminPermission('');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkSysadminPermission([]);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkSysadminPermission('admin[1]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkSysadminPermission(['admin[1]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkSysadminPermission('sysadmin');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkSysadminPermission(['sysadmin']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#checkPermission.
+     *
+     * @return void
+     */
+    public function testCheckPermission()
+    {
+        $haystackPerm = 'lang[1],client[2]';
+
+        $result = cPermission::checkPermission($haystackPerm, '');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, []);
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, 'lang[4]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, ['lang[4]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, 'lang[4],client[2]');
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, ['lang[4]', 'client[2]']);
+        $this->assertEquals(false, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, 'lang[1],client[2]');
+        $this->assertEquals(true, $result);
+
+        $result = cPermission::checkPermission($haystackPerm, ['lang[1]', 'client[2]']);
+        $this->assertEquals(true, $result);
+    }
+
+    /**
+     * Test cPermission#isAdmin with a cApiUser instance.
+     *
+     * @return void
+     */
+    public function testIsAdminApiUser()
+    {
+        $permission = new cPermission();
+
+        $cApiUserStub = $this->createApiUserStub('client[1]');
+        $this->assertEquals(false, $permission->isAdmin($cApiUserStub));
+
+        $cApiUserStub = $this->createApiUserStub('client[1],lang[1]');
+        $this->assertEquals(false, $permission->isAdmin($cApiUserStub));
+
+        $cApiUserStub = $this->createApiUserStub('admin[1]');
+        $this->assertEquals(true, $permission->isAdmin($cApiUserStub));
+
+        $cApiUserStub = $this->createApiUserStub('sysadmin');
+        $this->assertEquals(true, $permission->isAdmin($cApiUserStub));
+
+        $cApiUserStub = $this->createApiUserStub('sysadmin');
+        $this->assertEquals(false, $permission->isAdmin($cApiUserStub, true));
+    }
+
+    /**
+     * Creates a mock object of cApiUser.
+     *
+     * @param $methodReturnValue
+     * @return cApiUser|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createApiUserStub($methodReturnValue)
+    {
+        $stub = $this->getMockBuilder(cApiUser::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('getEffectiveUserPerms')
+            ->willReturn($methodReturnValue);
+
+        return $stub;
+    }
+
+}


### PR DESCRIPTION
- Moved admin checks into in cPermission
- Added isAdmin() method to cPermission
- Added static methods to cPermission to do common checks
- Unit tests for the new methods in cPermission
- Added prepare() method to cItemBaseAbstract to do similar sql statement replacements like in cDbDriverHandler::prepare()