### PR TITLE
Change fallback similartiy from 0 to 0.0001

### DIFF
--- a/contenido/classes/search/class.search.result.php
+++ b/contenido/classes/search/class.search.result.php
@@ -343,7 +343,7 @@ class cSearchResult extends cSearchBaseAbstract {
      *         Similarity between searchword and matching word in article
      */
     public function getSimilarity($art_id) {
-        return isset($this->_searchResult[$art_id]['similarity']) ? $this->_searchResult[$art_id]['similarity'] : 0;
+        return isset($this->_searchResult[$art_id]['similarity']) ? $this->_searchResult[$art_id]['similarity'] : 0.0001;
     }
 
     /**


### PR DESCRIPTION
I believe it should not be 0 because in line 160 we multiply with getOccurrence(). If it is 0 the occurrence does not matter at all and the result is always 0 => no sorting. I propose to have it slightly above 0. Might be an edge case but it was relevant for my customer.