### PR TITLE
Fix #241 short delay after failed login (frontend)

### DIFF
--- a/contenido/classes/auth/class.auth.handler.backend.php
+++ b/contenido/classes/auth/class.auth.handler.backend.php
@@ -143,7 +143,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
 
         if ($uid == false || hash("sha256", md5($password) . $salt) != $pass) {
             // No user found, sleep and exit
-            sleep(5);
+            sleep(2);
 
             return false;
         }

--- a/contenido/classes/auth/class.auth.handler.frontend.php
+++ b/contenido/classes/auth/class.auth.handler.frontend.php
@@ -150,7 +150,7 @@ class cAuthHandlerFrontend extends cAuthHandlerAbstract {
         }
 
         if ($uid == false || hash("sha256", md5($password) . $salt) != $pass) {
-            sleep(5);
+            sleep(2);
 
             return false;
         }


### PR DESCRIPTION
As complained in #241 the 5 seconds delay is very long. I propose to reduce it to 2 second. That should be enough.