### PR TITLE
#38 cAuth calls abstract methods of cAuthHandlerAbstract

### DIFF
--- a/contenido/classes/auth/class.auth.handler.abstract.php
+++ b/contenido/classes/auth/class.auth.handler.abstract.php
@@ -18,52 +18,20 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  * This class is the abstract authentication handler for CONTENIDO
  * which may be extended differently for frontend and backend authentication.
  *
+ * NOTE:
+ * Moved all abtract method declarations to `cAuth` class since `cAuth` calls
+ * some of them. There is no need to split abtract method definitions between
+ * `cAuthHandlerAbstract` and `cAuth`.
+ * Please update your class definition, in case you've implemented your own
+ * authentication handler as follows:
+ * <pre>
+ * class MyCustomAuthHandler extends cAuth { ... }
+ * </pre>
+ *
  * @package    Core
  * @subpackage Authentication
+ * @deprecated Since 4.10.2, use {@see cAuth} instead
  */
 abstract class cAuthHandlerAbstract extends cAuth {
-
-    /**
-     * Handle the pre authorization.
-     *
-     * When implementing this method let it return a valid user ID to be
-     * set before the login form is handled, otherwise false.
-     *
-     * @todo should be named preAuth or preAuthenticate
-     * @return string|false
-     */
-    abstract public function preAuthorize();
-
-    /**
-     * Display the login form.
-     *
-     * When implementing this method let this method include a file
-     * which displays the login form.
-     */
-    abstract public function displayLoginForm();
-
-    /**
-     * Validate the credentials.
-     *
-     * When implementing this method let this method validate the users
-     * input against source and return a valid user ID or false.
-     *
-     * @return string|false
-     */
-    abstract public function validateCredentials();
-
-    /**
-     * Log a successful authentication.
-     * This method can be executed to log a successful login.
-     */
-    abstract public function logSuccessfulAuth();
-
-
-    /**
-     * Returns true if a user is logged in
-     *
-     * @return bool
-     */
-    abstract public function isLoggedIn();
 
 }

--- a/contenido/classes/auth/class.auth.handler.backend.php
+++ b/contenido/classes/auth/class.auth.handler.backend.php
@@ -20,7 +20,7 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  * @package    Core
  * @subpackage Authentication
  */
-class cAuthHandlerBackend extends cAuthHandlerAbstract {
+class cAuthHandlerBackend extends cAuth {
 
     /**
      * Constructor to create an instance of this class.
@@ -30,40 +30,39 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
      */
     public function __construct() {
         $cfg = cRegistry::getConfig();
-        $this->_lifetime = (int) $cfg['backend']['timeout'];
+        $this->_lifetime = cSecurity::toInteger($cfg['backend']['timeout']);
         if ($this->_lifetime == 0) {
             $this->_lifetime = 15;
         }
     }
 
     /**
-     * Handle the pre authentication.
+     * There is no pre authentication in backend.
      *
-     * There is no pre authentication in backend so false is returned.
-     *
-     * @see cAuthHandlerAbstract::preAuthorize()
-     * @return false
+     * @inheritdoc
      */
-    public function preAuthorize() {
+    public function preAuthenticate() {
         return false;
     }
 
     /**
-     * Display the login form.
-     * Includes a file which displays the login form.
-     *
-     * @see cAuthHandlerAbstract::displayLoginForm()
-     *
-     * @throws cDbException
-     * @throws cException
-     * @throws cInvalidArgumentException
+     * @deprecated Since 4.10.2, use {@see cAuthHandlerBackend::preAuthenticate} instead
+     */
+    public function preAuthorize() {
+        return $this->preAuthenticate();
+    }
+
+    /**
+     * Includes a file which displays the backend login form.
+     * @inheritdoc
+     * @throws cDbException|cException|cInvalidArgumentException
      */
     public function displayLoginForm() {
         // @TODO  We need a better solution for this.
         //        One idea could be to set the request/response type in
         //        global $cfg array instead of checking $_REQUEST['ajax']
         //        everywhere...
-        if (isset($_REQUEST['ajax']) && $_REQUEST['ajax'] != '') {
+        if ($_REQUEST['ajax'] ?? '' != '') {
             $oAjax = new cAjaxRequest();
             $sReturn = $oAjax->handle('authentication_fail');
             echo $sReturn;
@@ -73,22 +72,13 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
     }
 
     /**
-     * Validate the credentials.
-     *
-     * Validate the users input against source and return a valid user
-     * ID or false.
-     *
-     * @see cAuthHandlerAbstract::validateCredentials()
-     *
-     * @return string|false
-     *
-     * @throws cDbException
-     * @throws cException
+     * @inheritdoc
+     * @throws cDbException|cException
      */
     public function validateCredentials() {
-        $username = isset($_POST['username']) ? $_POST['username'] : '';
-        $password = isset($_POST['password']) ? $_POST['password'] : '';
-        $formtimestamp = isset($_POST['formtimestamp']) ? $_POST['formtimestamp'] : '';
+        $username = $_POST['username'] ?? '';
+        $password = $_POST['password'] ?? '';
+        $formtimestamp = $_POST['formtimestamp'] ?? '';
 
         // add slashes if they are not automatically added
         if (cRegistry::getConfigValue('simulate_magic_quotes') !== true) {
@@ -110,7 +100,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
 
         if (isset($username)) {
             $this->auth['uname'] = $username;
-        } else if ($this->_defaultNobody == true) {
+        } else if ($this->_defaultNobody) {
             $uid = $this->auth['uname'] = $this->auth['uid'] = self::AUTH_UID_NOBODY;
 
             return $uid;
@@ -141,7 +131,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
             $salt = $item->get("salt");
         }
 
-        if ($uid == false || hash("sha256", md5($password) . $salt) != $pass) {
+        if (!$uid || hash("sha256", md5($password) . $salt) != $pass) {
             // No user found, sleep and exit
             sleep(2);
 
@@ -173,10 +163,9 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
      * Eventually the global $saveLoginTime is set to true which will trigger the update of the user properties
      * "currentlogintime" and "lastlogintime" in mycontenido.
      *
-     * @see cAuthHandlerAbstract::logSuccessfulAuth()
+     * @inheritdoc
      *
-     * @throws cDbException
-     * @throws cException
+     * @throws cDbException|cException
      */
     public function logSuccessfulAuth() {
         global $client, $lang, $saveLoginTime;
@@ -210,9 +199,7 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
         }
 
         $idaction = $perm->getIdForAction('login');
-
-        $authInfo = $this->getAuthInfo();
-        $uid = $authInfo['uid'];
+        $uid = $this->getUserId();
 
         // create a actionlog entry
         $actionLogCol = new cApiActionlogCollection();
@@ -224,16 +211,13 @@ class cAuthHandlerBackend extends cAuthHandlerAbstract {
     }
 
     /**
-     * Returns true if a user is logged in.
-     *
-     * @see cAuthHandlerAbstract::isLoggedIn()
+     * @inheritdoc
      * @return bool
      */
     public function isLoggedIn() {
-        $authInfo = $this->getAuthInfo();
-
-        if(isset($authInfo['uid'])) {
-            $user = new cApiUser($authInfo['uid']);
+        $userId = $this->getUserId();
+        if (!empty($userId)) {
+            $user = new cApiUser($userId);
 
             return $user->get('user_id') != '';
         } else {

--- a/contenido/classes/class.array.php
+++ b/contenido/classes/class.array.php
@@ -231,4 +231,21 @@ class cArray {
         return NULL;
     }
 
+
+    /**
+     * Get the last key of an array.
+     *
+     * @since CONTENIDO 4.10.2
+     * @param array $array An array
+     * @return int|string|null
+     */
+    public static function getLastKey(array $array) {
+        // We could use array_key_last(), but only from PHP >= 7.3.0
+        // see https://www.php.net/manual/en/function.array-key-last.php
+        if (empty($array)) {
+            return NULL;
+        }
+        return array_keys($array)[count($array) - 1];
+    }
+
 }

--- a/contenido/classes/class.registry.php
+++ b/contenido/classes/class.registry.php
@@ -488,7 +488,7 @@ class cRegistry {
             return $clientConfig;
         }
 
-        return (isset($clientConfig[$clientId]) ? $clientConfig[$clientId] : []);
+        return $clientConfig[$clientId] ?? [];
     }
 
     /**
@@ -553,7 +553,7 @@ class cRegistry {
      * @return mixed
      */
     public static function getAppVar($key, $default = NULL) {
-        return (isset(self::$_appVars[$key])) ? self::$_appVars[$key] : $default;
+        return self::$_appVars[$key] ?? $default;
     }
 
     /**
@@ -578,11 +578,7 @@ class cRegistry {
      * @return mixed
      */
     protected final static function _fetchGlobalVariable($variableName, $defaultValue = NULL) {
-        if (!isset($GLOBALS[$variableName])) {
-            return $defaultValue;
-        }
-
-        return $GLOBALS[$variableName];
+        return $GLOBALS[$variableName] ?? $defaultValue;
     }
 
     /**
@@ -640,20 +636,20 @@ class cRegistry {
 
         if (isset($sessClass)) {
             global $sess;
-            /** @var cSession */
+            /** @var cSession $sess */
             $sess = new $sessClass();
             $sess->start();
             if (isset($authClass)) {
                 global $auth;
                 if (!isset($auth)) {
-                    /** @var cAuthHandlerAbstract */
+                    /** @var cAuth $auth */
                     $auth = new $authClass();
                 }
                 $auth->start();
                 if (isset($permClass)) {
                     global $perm;
                     if (!isset($perm)) {
-                        /** @var cPermission */
+                        /** @var cPermission $perm */
                         $perm = new $permClass();
                     }
                 }
@@ -671,7 +667,7 @@ class cRegistry {
      * @throws cInvalidArgumentException
      */
     public final static function shutdown($debugShowAll = true) {
-        if ($debugShowAll == true) {
+        if ($debugShowAll) {
             cDebug::showAll();
         }
 
@@ -688,7 +684,7 @@ class cRegistry {
      * @param string $message
      */
     public static function addOkMessage($message) {
-        array_push(self::$_okMessages, $message);
+        self::$_okMessages[] = $message;
     }
 
 
@@ -699,7 +695,7 @@ class cRegistry {
      * @param string $message
      */
     public static function addInfoMessage($message) {
-        array_push(self::$_infoMessages, $message);
+        self::$_infoMessages[] = $message;
     }
 
     /**
@@ -709,7 +705,7 @@ class cRegistry {
      * @param string $message
      */
     public static function addErrorMessage($message) {
-        array_push(self::$_errMessages, $message);
+        self::$_errMessages[] = $message;
     }
 
     /**
@@ -719,7 +715,7 @@ class cRegistry {
      * @param string $message
      */
     public static function addWarningMessage($message) {
-        array_push(self::$_warnMessages, $message);
+        self::$_warnMessages[] = $message;
     }
 
     /**
@@ -729,14 +725,12 @@ class cRegistry {
      * @param string $message
      */
     public static function appendLastOkMessage($message) {
-        if(count(self::$_okMessages) == 0) {
+        $key = cArray::getLastKey(self::$_okMessages);
+        if (is_null($key)) {
             self::$_okMessages[] = $message;
-            return;
+        } else {
+            self::$_okMessages[$key] .= "<br>" . $message;
         }
-        end(self::$_okMessages);
-        $lastKey = key(self::$_okMessages);
-        self::$_okMessages[$lastKey] .= "<br>" . $message;
-        reset(self::$_okMessages);
     }
 
     /**
@@ -746,14 +740,12 @@ class cRegistry {
      * @param string $message
      */
     public static function appendLastInfoMessage($message) {
-        if(count(self::$_infoMessages) == 0) {
+        $key = cArray::getLastKey(self::$_infoMessages);
+        if (is_null($key)) {
             self::$_infoMessages[] = $message;
-            return;
+        } else {
+            self::$_infoMessages[$key] .= "<br>" . $message;
         }
-        end(self::$_infoMessages);
-        $lastKey = key(self::$_infoMessages);
-        self::$_infoMessages[$lastKey] .= "<br>" . $message;
-        reset(self::$_infoMessages);
     }
 
     /**
@@ -763,14 +755,12 @@ class cRegistry {
      * @param string $message
      */
     public static function appendLastErrorMessage($message) {
-        if(count(self::$_errMessages) == 0) {
+        $key = cArray::getLastKey(self::$_errMessages);
+        if (is_null($key)) {
             self::$_errMessages[] = $message;
-            return;
+        } else {
+            self::$_errMessages[$key] .= "<br>" . $message;
         }
-        end(self::$_errMessages);
-        $lastKey = key(self::$_errMessages);
-        self::$_errMessages[$lastKey] .= "<br>" . $message;
-        reset(self::$_errMessages);
     }
 
     /**
@@ -780,14 +770,12 @@ class cRegistry {
      * @param string $message
      */
     public static function appendLastWarningMessage($message) {
-        if(count(self::$_warnMessages) == 0) {
+        $key = cArray::getLastKey(self::$_warnMessages);
+        if (is_null($key)) {
             self::$_warnMessages[] = $message;
-            return;
+        } else {
+            self::$_warnMessages[$key] .= "<br>" . $message;
         }
-        end(self::$_warnMessages);
-        $lastKey = key(self::$_warnMessages);
-        self::$_warnMessages[$lastKey] .= "<br>" . $message;
-        reset(self::$_warnMessages);
     }
 
     /**
@@ -838,7 +826,7 @@ class cRegistry {
      *         whether tracking is allowed by the DNT header
      */
     public static function isTrackingAllowed() {
-        return (isset($_SERVER['HTTP_DNT']) && $_SERVER['HTTP_DNT'] != 1) || !isset($_SERVER['HTTP_DNT']);
+        return cSecurity::toInteger($_SERVER['HTTP_DNT'] ?? '0') === 1;
     }
 
     /**
@@ -848,7 +836,6 @@ class cRegistry {
     *         name of encoding or false if no language found
     */
     public static function getEncoding() {
-
         $apiLanguage = new cApiLanguage(self::getLanguageId());
         if ($apiLanguage->isLoaded()) {
             return trim($apiLanguage->get('encoding'));
@@ -856,4 +843,5 @@ class cRegistry {
 
         return false;
     }
+
 }


### PR DESCRIPTION
Marked `cAuthHandlerAbstract` as deprecated, moved abstract methods to `cAuth` and declared `cAuth` as abstract.

`cAuthHandlerBackend` and `cAuthHandlerFrontend` extends `cAuth`, and `cAuthHandlerAbstract` also extends `cAuth` in case someone has implemented a custom authentication handler.

Reworked some parts of `cAuthHandlerBackend`, `cAuthHandlerFrontend`, and `cRegistry`. Added new method `getLastKey()` to `cArray`.