### PR TITLE
#242 No upload directory is set in CMS_IMGEDITOR on load.

### DIFF
--- a/contenido/classes/content_types/class.content.type.imgeditor.php
+++ b/contenido/classes/content_types/class.content.type.imgeditor.php
@@ -321,6 +321,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed {
         }
 
         if (empty($filename)) {
+            $this->_rawSettings = '';
             return;
         }
 

--- a/contenido/scripts/content_types/cmsImgeditor.js
+++ b/contenido/scripts/content_types/cmsImgeditor.js
@@ -137,6 +137,7 @@
             // if the upload tab is shown, show the directories tab, too
             if ($(this).hasClass('upload')) {
                 $(self.frameId + ' .tabs #directories').show();
+                self.showFolderPath();
             }
         });
     };


### PR DESCRIPTION
Took over the fix from ticket. Fixed also the issue with unselecting a previous selected images.