### PR TITLE
refactored else if to elseif

### DIFF
--- a/contenido/classes/auth/class.auth.handler.backend.php
+++ b/contenido/classes/auth/class.auth.handler.backend.php
@@ -100,7 +100,7 @@ class cAuthHandlerBackend extends cAuth {
 
         if (isset($username)) {
             $this->auth['uname'] = $username;
-        } else if ($this->_defaultNobody) {
+        } elseif ($this->_defaultNobody) {
             $uid = $this->auth['uname'] = $this->auth['uid'] = self::AUTH_UID_NOBODY;
 
             return $uid;

--- a/contenido/classes/class.array.php
+++ b/contenido/classes/class.array.php
@@ -96,7 +96,7 @@ class cArray {
                     // convert $search explicitly to string
                     // we do not want to use the ordinal value of $search
                     $found = false !== cString::findFirstPos($value, strval($search));
-               } else if ($strict == true) {
+               } elseif ($strict == true) {
                     // search by identity
                     $found = $value === $search;
                 } else {

--- a/contenido/classes/class.cziparchive.php
+++ b/contenido/classes/class.cziparchive.php
@@ -50,7 +50,7 @@ class cZipArchive {
                 // exclude file if name starts with a dot
                 // hotfix : fileHandler returns filename '.' als valid filename
                 continue;
-            } else if (!cFileHandler::validateFilename($file, false)) {
+            } elseif (!cFileHandler::validateFilename($file, false)) {
                 // exclude file if name is not valid according to CONTENIDO
                 // standards
                 continue;
@@ -72,7 +72,7 @@ class cZipArchive {
     public static function isExtracted($dirPath) {
         if (!file_exists($dirPath)) {
             return false;
-        } else if (!is_dir($dirPath)) {
+        } elseif (!is_dir($dirPath)) {
             return false;
         } else {
             return true;

--- a/contenido/classes/class.dirhandler.php
+++ b/contenido/classes/class.dirhandler.php
@@ -345,7 +345,7 @@ class cDirHandler {
                             $dirContent[] = $file;
                         }
                     // bugfix: is_dir only checked file name without path, thus returning everything most of the time
-                    } else if ($fileOnly === true) { // get only files
+                    } elseif ($fileOnly === true) { // get only files
 
                         if (is_file($dirname . $file)) {
                             $dirContent[] = $file;
@@ -367,7 +367,7 @@ class cDirHandler {
                         // get only directories
                         $dirContent[] = $fileName;
 
-                    } else if ($fileOnly === true && is_file($fileName)) {
+                    } elseif ($fileOnly === true && is_file($fileName)) {
                         // get only files
                         $dirContent[] = $fileName;
 

--- a/contenido/classes/class.effective.setting.php
+++ b/contenido/classes/class.effective.setting.php
@@ -178,7 +178,7 @@ class cEffectiveSetting {
 
         if (false === $value || NULL === $value) {
             $value = $default;
-        } else if ('' === $value && '' !== $default) {
+        } elseif ('' === $value && '' !== $default) {
             // NOTE: A non empty default value overrides an empty value
             $value = $default;
         }

--- a/contenido/classes/class.filehandler.php
+++ b/contenido/classes/class.filehandler.php
@@ -77,11 +77,11 @@ class cFileHandler {
 
         if ($reverse) {
             return file_get_contents($filename, false, NULL, filesize($filename) - $length - $offset, $length);
-        } else if ($length > 0 && $offset == 0) {
+        } elseif ($length > 0 && $offset == 0) {
             return file_get_contents($filename, false, NULL, 0, $length);
-        } else if ($offset > 0 && $length == 0) {
+        } elseif ($offset > 0 && $length == 0) {
             return file_get_contents($filename, false, NULL, $offset);
-        } else if ($offset > 0 && $length > 0) {
+        } elseif ($offset > 0 && $length > 0) {
             return file_get_contents($filename, false, NULL, $offset, $length);
         } else {
             return file_get_contents($filename);

--- a/contenido/classes/class.input.helper.php
+++ b/contenido/classes/class.input.helper.php
@@ -116,7 +116,7 @@ class cHTMLInputSelectElement extends cHTMLSelectElement {
                                 // Start article -> blue
                                 $oOption->setStyle('color: #0000ff;');
                             }
-                        } else if ($oDB->f('online') == 0) {
+                        } elseif ($oDB->f('online') == 0) {
                             // Offline article -> grey
                             $oOption->setStyle('color: #666666;');
                         }
@@ -202,7 +202,7 @@ class cHTMLInputSelectElement extends cHTMLSelectElement {
                     // If category has to be visible or public and it isn't,
                     // don't add value
                     $sValue = '';
-                } else if ($bWithArt) {
+                } elseif ($bWithArt) {
                     // If article will be added, set negative idcat as value
                     $sValue = '-' . $iID;
                 } else {

--- a/contenido/classes/class.mailer.php
+++ b/contenido/classes/class.mailer.php
@@ -481,7 +481,7 @@ class cMailer extends Swift_Mailer {
                 }
             }
             return $value;
-        } else if (is_string($value)) {
+        } elseif (is_string($value)) {
             return conHtmlentities($value, ENT_COMPAT, $charset);
         } else {
             return $value;
@@ -507,7 +507,7 @@ class cMailer extends Swift_Mailer {
                 }
             }
             return $value;
-        } else if (is_string($value)) {
+        } elseif (is_string($value)) {
             return conHtmlEntityDecode($value, ENT_COMPAT | ENT_HTML401, $charset);
         } else {
             return $value;

--- a/contenido/classes/class.pager.php
+++ b/contenido/classes/class.pager.php
@@ -133,7 +133,7 @@ class cPager {
     public function getMaxPages() {
         if ($this->_items == 0) {
             return 1;
-        } else if ($this->_itemsPerPage == 0) {
+        } elseif ($this->_itemsPerPage == 0) {
             return 1;
         } else {
             return ceil($this->_items / $this->_itemsPerPage);

--- a/contenido/classes/class.string.php
+++ b/contenido/classes/class.string.php
@@ -235,13 +235,13 @@ class cString extends cStringMultiByteWrapper {
             if ($char < 0x80) {
                 // ASCII char
                 continue;
-            } else if (($char & 0xE0) === 0xC0 && $char > 0xC1) {
+            } elseif (($char & 0xE0) === 0xC0 && $char > 0xC1) {
                 // 2 byte long char
                 $n = 1;
-            } else if (($char & 0xF0) === 0xE0) {
+            } elseif (($char & 0xF0) === 0xE0) {
                 // 3 byte long char
                 $n = 2;
-            } else if (($char & 0xF8) === 0xF0 && $char < 0xF5) {
+            } elseif (($char & 0xF8) === 0xF0 && $char < 0xF5) {
                 // 4 byte long char
                 $n = 3;
             } else {
@@ -359,7 +359,7 @@ class cString extends cStringMultiByteWrapper {
         if ($maximum_text_length > 0) {
             if (preg_match('/(*UTF8)^.{0,' . $maximum_text_length . '}/', $string, $result_array)) {
                 $cutted_string = $result_array[0];
-            } else if (preg_match('/^.{0,' . $maximum_text_length . '}/u', $string, $result_array)) {
+            } elseif (preg_match('/^.{0,' . $maximum_text_length . '}/u', $string, $result_array)) {
                 $cutted_string = $result_array[0];
             } else {
                 $cutted_string = parent::getPartOfString($string, 0, $maximum_text_length);

--- a/contenido/classes/class.systemtest.php
+++ b/contenido/classes/class.systemtest.php
@@ -1132,9 +1132,9 @@ class cSystemtest {
 
             if (array_key_exists('frontend', $file) && $frontend != false) {
                 $ret = $this->testSingleFile($name, $severity, $frontend);
-            } else if (array_key_exists('config', $file) && $config != false) {
+            } elseif (array_key_exists('config', $file) && $config != false) {
                 $ret = $this->testSingleFile($name, $severity);
-            } else if (!array_key_exists('frontend', $file) && !array_key_exists('config', $file)) {
+            } elseif (!array_key_exists('frontend', $file) && !array_key_exists('config', $file)) {
                 $ret = $this->testSingleFile($name, $severity, $config);
             }
             if ($ret == false) {

--- a/contenido/classes/class.update.notifier.php
+++ b/contenido/classes/class.update.notifier.php
@@ -331,11 +331,11 @@ class cUpdateNotifier {
     protected function updateSystemProperty($sAction) {
         if ($sAction == "activate") {
             setSystemProperty($this->aSysPropConf['type'], $this->aSysPropConf['name'], "true");
-        } else if ($sAction == "deactivate") {
+        } elseif ($sAction == "deactivate") {
             setSystemProperty($this->aSysPropConf['type'], $this->aSysPropConf['name'], "false");
-        } else if ($sAction == "activate_rss") {
+        } elseif ($sAction == "activate_rss") {
             setSystemProperty($this->aSysPropConfRss['type'], $this->aSysPropConfRss['name'], "true");
-        } else if ($sAction == "deactivate_rss") {
+        } elseif ($sAction == "deactivate_rss") {
             setSystemProperty($this->aSysPropConfRss['type'], $this->aSysPropConfRss['name'], "false");
         }
     }
@@ -728,7 +728,7 @@ class cUpdateNotifier {
                 $oTpl->set("s", "NEWS_NOCONTENT", "");
                 $oTpl->set("s", "DISPLAY_DISABLED", 'none');
             }
-        } else if ($this->bNoWritePermissions == true) {
+        } elseif ($this->bNoWritePermissions == true) {
             $oTpl->set("s", "NEWS_NOCONTENT", i18n('Your webserver does not have write permissions for the directory /contenido/data/cache/!'));
         } else {
             $oTpl->set("s", "NEWS_NOCONTENT", i18n("No RSS content available"));
@@ -775,25 +775,25 @@ class cUpdateNotifier {
     public function displayOutput() {
         if (!$this->bEnableView) {
             $sOutput = "";
-        } else if ($this->bNoWritePermissions == true) {
+        } elseif ($this->bNoWritePermissions == true) {
             $sMessage = i18n('Your webserver does not have write permissions for the directory /contenido/data/cache/!');
             $sOutput = $this->renderOutput($sMessage);
-        } else if (!$this->bEnableCheck) {
+        } elseif (!$this->bEnableCheck) {
             $sMessage = i18n('Update notification is disabled! For actual update information, please activate.');
             $sOutput = $this->renderOutput($sMessage);
-        } else if ($this->sErrorOutput != "") {
+        } elseif ($this->sErrorOutput != "") {
             $sOutput = $this->sErrorOutput;
-        } else if ($this->sVendorVersion == '') {
+        } elseif ($this->sVendorVersion == '') {
             $sMessage = i18n('You have an unknown or unsupported version of CONTENIDO!');
             $sOutput = $this->renderOutput($sMessage);
-        } else if ($this->sVendorVersion == "deprecated") {
+        } elseif ($this->sVendorVersion == "deprecated") {
             $sMessage = sprintf(i18n("Your version of CONTENIDO is deprecated and not longer supported for any updates. Please update to a higher version! <br /> <a href='%s' class='blue' target='_blank'>Download now!</a>"), 'http://www.contenido.org');
             $sOutput = $this->renderOutput($sMessage);
-        } else if ($this->checkPatchLevel() == "-1") {
+        } elseif ($this->checkPatchLevel() == "-1") {
             $sVendorDownloadURL = $this->getDownloadURL();
             $sMessage = sprintf(i18n("A new version of CONTENIDO is available! <br /> <a href='%s' class='blue' target='_blank'>Download %s now!</a>"), $sVendorDownloadURL, $this->sVendorVersion);
             $sOutput = $this->renderOutput($sMessage);
-        } else if ($this->checkPatchLevel() == "1") {
+        } elseif ($this->checkPatchLevel() == "1") {
             $sMessage = sprintf(i18n('It seems to be that your version string was manipulated. CONTENIDO %s does not exist!'), CON_VERSION);
             $sOutput = $this->renderOutput($sMessage);
         } else {

--- a/contenido/classes/code_generator/class.code.generator.abstract.php
+++ b/contenido/classes/code_generator/class.code.generator.abstract.php
@@ -389,13 +389,13 @@ abstract class cCodeGeneratorAbstract {
                     if (cRegistry::isBackendEditMode()) {
                         //if ($editable) {
                             $tmp = $cTypeObject->generateEditCode();
-                        //} else if ($typeClassName !== 'cContentTypeImgeditor') {
+                        //} elseif ($typeClassName !== 'cContentTypeImgeditor') {
                         //    $tmp = $cTypeObject->generateViewCode();
                         //}
                     } else {
                         $tmp = $cTypeObject->generateViewCode();
                     }
-                } else if (cFileHandler::exists($typeCodeFile)) {
+                } elseif (cFileHandler::exists($typeCodeFile)) {
                     // include CMS type code file
                     include($typeCodeFile);
                 }
@@ -539,7 +539,7 @@ abstract class cCodeGeneratorAbstract {
                     $this->_idart,
                     $this->_lang
             );
-        } else if (is_numeric($version)) {
+        } elseif (is_numeric($version)) {
             $sql = 'SELECT b.type as type, a.typeid as typeid, a.value as value
                     FROM `%s` AS a
                     INNER JOIN `%s` as b

--- a/contenido/classes/code_generator/class.code.generator.standard.php
+++ b/contenido/classes/code_generator/class.code.generator.standard.php
@@ -196,7 +196,7 @@ class cCodeGeneratorStandard extends cCodeGeneratorAbstract {
         // or after opening head tag
         if (cString::findFirstPos($this->_layoutCode, '{CSS}') !== false) {
             $this->_layoutCode = cString::iReplaceOnce('{CSS}', $cssFile, $this->_layoutCode);
-        } else if (!empty($cssFile)) {
+        } elseif (!empty($cssFile)) {
             if (cString::findFirstPos($this->_layoutCode, '</title>') !== false) {
                 $matches = [];
                 if (preg_match_all("#(<head>.*?</title>)(.*?</head>)#si", $this->_layoutCode, $matches)) {
@@ -215,7 +215,7 @@ class cCodeGeneratorStandard extends cCodeGeneratorAbstract {
         // or before closing body tag if there is no {JS}
         if (cString::findFirstPos($this->_layoutCode, '{JS}') !== false) {
             $this->_layoutCode = cString::iReplaceOnce('{JS}', $jsFile, $this->_layoutCode);
-        } else if (!empty($jsFile)) {
+        } elseif (!empty($jsFile)) {
             $this->_layoutCode = cString::iReplaceOnce('</body>', $jsFile . '</body>', $this->_layoutCode);
         }
 
@@ -549,7 +549,7 @@ class cCodeGeneratorStandard extends cCodeGeneratorAbstract {
                 $index = (bool) (in_array('all', $content) || in_array('index', $content));
                 if (in_array('index', $content) || in_array('all', $content)) {
                     $index = true;
-                } else if (in_array('noindex', $content)) {
+                } elseif (in_array('noindex', $content)) {
                     $index = true;
                 } else {
                     $index = NULL;
@@ -559,7 +559,7 @@ class cCodeGeneratorStandard extends cCodeGeneratorAbstract {
             if (is_null($follow)) {
                 if (in_array('follow', $content) || in_array('all', $content)) {
                     $follow = true;
-                } else if (in_array('nofollow', $content)) {
+                } elseif (in_array('nofollow', $content)) {
                     $follow = true;
                 } else {
                     $follow = NULL;
@@ -614,10 +614,10 @@ class cCodeGeneratorStandard extends cCodeGeneratorAbstract {
             if (!is_array($metaTag)) {
                 // skip $metaTag if it's no array
                 continue;
-            } else if (!array_key_exists($type, $metaTag)) {
+            } elseif (!array_key_exists($type, $metaTag)) {
                 // add element to reduced array if it's of different type
                 $result[0][] = $metaTag;
-            } else if ($metaTag[$type] !== $nameOrEquiv) {
+            } elseif ($metaTag[$type] !== $nameOrEquiv) {
                 // add element to reduced array if it has different name
                 $result[0][] = $metaTag;
             } else {

--- a/contenido/classes/content_types/class.content.type.abstract.php
+++ b/contenido/classes/content_types/class.content.type.abstract.php
@@ -381,7 +381,7 @@ abstract class cContentTypeAbstract {
                 $keyWithoutPrefix = str_replace($this->_prefix . '_', '', $key);
                 if (isset($_POST[$key])) {
                     $this->setSetting($key, $_POST[$key]);
-                } else if (isset($_POST[$this->_prefix . '_array_' . $keyWithoutPrefix])) {
+                } elseif (isset($_POST[$this->_prefix . '_array_' . $keyWithoutPrefix])) {
                     // key is of type prefix_array_field, so interpret value as an array
                     $value = explode(',', $_POST[$this->_prefix . '_array_' . $keyWithoutPrefix]);
                     $this->setSetting($key, $value);
@@ -457,7 +457,7 @@ abstract class cContentTypeAbstract {
             $b = cString::toLowerCase($b["name"]);
             if ($a < $b) {
                 return -1;
-            } else if ($a > $b) {
+            } elseif ($a > $b) {
                 return 1;
             } else {
                 return 0;
@@ -494,7 +494,7 @@ abstract class cContentTypeAbstract {
             // check if the directory should be shown expanded or collapsed
             if ($this->_shouldDirectoryBeExpanded($dirData)) {
                 $template->set('d', 'SUBDIRLIST', $this->generateDirectoryList($dirData['sub']));
-            } else if (isset($dirData['sub']) && count($dirData['sub']) > 0) {
+            } elseif (isset($dirData['sub']) && count($dirData['sub']) > 0) {
                 $liClasses[] = 'collapsed';
                 $template->set('d', 'SUBDIRLIST', '');
             } else {

--- a/contenido/classes/content_types/class.content.type.filelist.php
+++ b/contenido/classes/content_types/class.content.type.filelist.php
@@ -246,7 +246,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed {
                     $fileList[] = $filename;
                 }
             }
-        } else if (is_array($this->getSetting('filelist_directories')) && count($this->getSetting('filelist_directories')) > 0) {
+        } elseif (is_array($this->getSetting('filelist_directories')) && count($this->getSetting('filelist_directories')) > 0) {
             $directories = $this->getSetting('filelist_directories');
 
             if ($this->getSetting('filelist_incl_subdirectories') === 'true') {
@@ -1115,7 +1115,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed {
             $b = cString::toLowerCase($b['name']);
             if ($a < $b) {
                 return -1;
-            } else if ($a > $b) {
+            } elseif ($a > $b) {
                 return 1;
             } else {
                 return 0;

--- a/contenido/classes/content_types/class.content.type.imgeditor.php
+++ b/contenido/classes/content_types/class.content.type.imgeditor.php
@@ -199,7 +199,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed {
                     'typeid' => $id
                 ]);
                 return $content->get('value');
-            } else if ($editable) {
+            } elseif ($editable) {
                 $db = cRegistry::getDb();
                 $sql = "SELECT MAX(`version`) AS `max` FROM `%s` WHERE `idartlang` = %d AND `typeid` = %d AND `idtype` = %d";
                 $sql = $db->prepare($sql, cRegistry::getDbTableName('content_version'), $idArtLang, $id, $idtype);
@@ -667,7 +667,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed {
             $b = cString::toLowerCase($b["name"]);
             if ($a < $b) {
                 return -1;
-            } else if ($a > $b) {
+            } elseif ($a > $b) {
                 return 1;
             } else {
                 return 0;

--- a/contenido/classes/content_types/class.content.type.linkeditor.php
+++ b/contenido/classes/content_types/class.content.type.linkeditor.php
@@ -209,7 +209,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed {
                     $uriBuilder->buildUrl($uriParams, true);
 
                     return $uriBuilder->getUrl();
-                } else if (cSecurity::isInteger($this->getSetting('linkeditor_idart'))) {
+                } elseif (cSecurity::isInteger($this->getSetting('linkeditor_idart'))) {
                     $oUri = cUri::getInstance();
                     $uriBuilder = $oUri->getUriBuilder();
                     $uriParams = [
@@ -477,7 +477,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed {
             // check if the category should be shown expanded or collapsed
             if (in_array($category['idcat'], $activeIdcats) && $category['sub'] != '') {
                 $template->set('d', 'SUBDIRLIST', $this->getCategoryList($category['sub']));
-            } else if ($category['sub'] != '' && count($category['sub']) > 0) {
+            } elseif ($category['sub'] != '' && count($category['sub']) > 0) {
                 $liClasses[] = 'collapsed';
                 $template->set('d', 'SUBDIRLIST', '');
             } else {
@@ -528,7 +528,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed {
                                 c.idclient = ' . cSecurity::toInteger($this->_client) . '
                             ORDER BY
                                 a.idtree';
-            } else if (cString::getPartOfString($linkEditorIdArt, 0, 8) == 'category') { // Selection of category (CON-2563)
+            } elseif (cString::getPartOfString($linkEditorIdArt, 0, 8) == 'category') { // Selection of category (CON-2563)
                 $sql = 'SELECT DISTINCT
                                 *
                            FROM
@@ -806,7 +806,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed {
                 $b = cString::toLowerCase($b["name"]);
                 if ($a < $b) {
                     return -1;
-                } else if ($a > $b) {
+                } elseif ($a > $b) {
                     return 1;
                 } else {
                     return 0;

--- a/contenido/classes/debug/class.debug.php
+++ b/contenido/classes/debug/class.debug.php
@@ -172,7 +172,7 @@ class cDebug {
         self::$_defaultDebuggerName = self::DEBUGGER_DEVNULL;
         if (getSystemProperty('debug', 'debug_to_file') == 'true') {
             self::$_defaultDebuggerName = self::DEBUGGER_FILE;
-        } else if (getSystemProperty('debug', 'debug_to_screen') == 'true') {
+        } elseif (getSystemProperty('debug', 'debug_to_screen') == 'true') {
             self::$_defaultDebuggerName = self::DEBUGGER_VISIBLE_ADV;
         }
         if ((getSystemProperty('debug', 'debug_to_screen') == 'true') && (getSystemProperty('debug', 'debug_to_file') == 'true')) {

--- a/contenido/classes/genericdb/class.item.base.abstract.php
+++ b/contenido/classes/genericdb/class.item.base.abstract.php
@@ -232,7 +232,7 @@ abstract class cItemBaseAbstract extends cGenericDb {
     public function __set($name, $value) {
         if ('primaryKey' === $name) {
             static::_setPrimaryKeyName($value);
-        } else if ('virgin' === $name) {
+        } elseif ('virgin' === $name) {
             static::_setLoaded(!(bool) $value);
         }
     }

--- a/contenido/classes/gui/class.page.php
+++ b/contenido/classes/gui/class.page.php
@@ -329,13 +329,13 @@ class cGuiPage {
             if (!in_array($script, $this->_scripts)) {
                 $this->_scripts[] = $script;
             }
-        } else if (!empty($this->_pluginName) && cFileHandler::exists($backendPath . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['scripts'] . $filePathName)) {
+        } elseif (!empty($this->_pluginName) && cFileHandler::exists($backendPath . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['scripts'] . $filePathName)) {
             // the given script path is relative to the plugin scripts folder
             $fullPath = $backendUrl . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['scripts'] . $script;
             if (!in_array($fullPath, $this->_scripts)) {
                 $this->_scripts[] = $fullPath;
             }
-        } else if (cFileHandler::exists($backendPath . $cfg['path']['scripts'] . $filePathName)) {
+        } elseif (cFileHandler::exists($backendPath . $cfg['path']['scripts'] . $filePathName)) {
             // the given script path is relative to the CONTENIDO scripts folder
             $fullPath = $backendUrl . $cfg['path']['scripts'] . $script;
 
@@ -379,14 +379,14 @@ class cGuiPage {
             if (!in_array($stylesheet, $this->_styles)) {
                 $this->_styles[] = $stylesheet;
             }
-        } else if (!empty($this->_pluginName) && cFileHandler::exists($backendPath . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['styles'] . $filePathName)) {
+        } elseif (!empty($this->_pluginName) && cFileHandler::exists($backendPath . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['styles'] . $filePathName)) {
             // the given stylesheet path is relative to the plugin stylesheets
             // folder
             $fullPath = $backendUrl . $cfg['path']['plugins'] . $this->_pluginName . '/' . $cfg['path']['styles'] . $stylesheet;
             if (!in_array($fullPath, $this->_styles)) {
                 $this->_styles[] = $fullPath;
             }
-        } else if (cFileHandler::exists($backendPath . $cfg['path']['styles'] . $filePathName)) {
+        } elseif (cFileHandler::exists($backendPath . $cfg['path']['styles'] . $filePathName)) {
             // the given stylesheet path is relative to the CONTENIDO
             // stylesheets folder
             $fullPath = $backendUrl . $cfg['path']['styles'] . $stylesheet;
@@ -821,7 +821,7 @@ class cGuiPage {
         foreach ($this->_scripts as $script) {
             if (cString::findFirstPos($script, 'http') === 0 || cString::findFirstPos($script, '//') === 0) {
                 $scripts .= '<script type="text/javascript" src="' . $script . '"></script>' . "\n";
-            } else if (cString::findFirstPos($script, '<script') === false) {
+            } elseif (cString::findFirstPos($script, '<script') === false) {
                 $scripts .= '<script type="text/javascript" src="scripts/' . $script . '"></script>' . "\n";
             } else {
                 $scripts .= $script;

--- a/contenido/classes/log/class.log.php
+++ b/contenido/classes/log/class.log.php
@@ -167,7 +167,7 @@ class cLog {
 
         if (!$writer) {
             $createWriter = true;
-        } else if (!is_object($writer) || !($writer instanceof cLogWriter)) {
+        } elseif (!is_object($writer) || !($writer instanceof cLogWriter)) {
             cWarning(__FILE__, __LINE__, 'The passed class is not a subclass of cLogWriter. Creating new one.');
             $createWriter = true;
         }

--- a/contenido/classes/version/class.version.php
+++ b/contenido/classes/version/class.version.php
@@ -422,7 +422,7 @@ class cVersion {
                     $bDelete = cDirHandler::remove($sDir);
                 }
             }
-        } else if ($sFirstFile != '') {
+        } elseif ($sFirstFile != '') {
             $bDelete = cFileHandler::remove($sDir . $sFirstFile);
         }
         if ($bDelete) {

--- a/contenido/classes/versioning/class.contentversioning.php
+++ b/contenido/classes/versioning/class.contentversioning.php
@@ -134,7 +134,7 @@ class cContentVersioning {
 
             if (false === $versioningState || NULL === $versioningState) {
                 $versioningState = 'disabled';
-            } else if ('' === $versioningState) {
+            } elseif ('' === $versioningState) {
                 // NOTE: An non empty default value overrides an empty value
                 $versioningState = 'disabled';
             }
@@ -171,10 +171,10 @@ class cContentVersioning {
             || ($articleType == 'version' && $versioningState == 'simple')) {
             if (is_numeric($idArtLangVersion) && $articleType == 'version') {
                 $this->selectedArticle = new cApiArticleLanguageVersion($idArtLangVersion);
-            } else if (isset($this->editableArticleId)) {
+            } elseif (isset($this->editableArticleId)) {
                 $this->selectedArticle = new cApiArticleLanguageVersion($this->editableArticleId);
             }
-        } else if ($articleType == 'current' || $articleType == 'editable') {
+        } elseif ($articleType == 'current' || $articleType == 'editable') {
             $this->selectedArticle = new cApiArticleLanguage($idArtLang);
         }
 
@@ -202,7 +202,7 @@ class cContentVersioning {
         if (($articleType == 'version' || $articleType == 'editable') && $this->getState() == 'advanced'
             || $articleType == 'version' && $this->getState() == 'simple') {
             $this->db->query($sql, cRegistry::getDbTableName('content_version'), cRegistry::getDbTableName('type'), $idArtLang);
-        } else if ($articleType == 'current' || $articleType == 'editable' && $this->getState() != 'advanced') {
+        } elseif ($articleType == 'current' || $articleType == 'editable' && $this->getState() != 'advanced') {
             $this->db->query($sql, cRegistry::getDbTableName('content'), cRegistry::getDbTableName('type'), $idArtLang);
         }
 
@@ -257,7 +257,7 @@ class cContentVersioning {
             || $this->editableArticleId == NULL
             && $action != 'con_meta_saveart' && $action != 'con_newart') { // advanced
             $this->articleType = 'current';
-        } else if ($this->getState() == 'advanced' && ($selectedArticleId == 'editable'
+        } elseif ($this->getState() == 'advanced' && ($selectedArticleId == 'editable'
             || $selectedArticleId == NULL || $this->editableArticleId === $selectedArticleId)
             && ($action == 'con_content' || $action == 'con_meta_deletetype'
                 || $action == 'con_meta_edit' || $action == 'con_edit' || $action == 'con_editart')
@@ -343,7 +343,7 @@ class cContentVersioning {
             $this->editableArticleId = $this->db->f('max');
 
             return $this->editableArticleId;
-        } else if ($this->getState() == 'simple' || $this->getState() == 'disabled') {
+        } elseif ($this->getState() == 'simple' || $this->getState() == 'disabled') {
             return $idArtLang;
         }
     }
@@ -452,7 +452,7 @@ class cContentVersioning {
                 $contentVersionMap = array_unique($contentVersionMap);
                 $artLangVersionColl->setWhere('version', $contentVersionMap, 'IN');
 
-            } else if ($selectElementType == 'seo') {
+            } elseif ($selectElementType == 'seo') {
 
                 // select only versions with different seo versions
                 $metaVersionColl = new cApiMetaTagVersionCollection();
@@ -476,7 +476,7 @@ class cContentVersioning {
                 $metaVersionMap = array_unique($metaVersionMap);
                 $artLangVersionColl->setWhere('version', $metaVersionMap, 'IN');
 
-            } else if ($selectElementType == 'config') {
+            } elseif ($selectElementType == 'config') {
 
                 // select all versions
 

--- a/contenido/classes/xml/class.xml.base.php
+++ b/contenido/classes/xml/class.xml.base.php
@@ -362,7 +362,7 @@ abstract class cXmlBase {
         // if array only contains empty values, return the array keys
         if (count(array_keys($array, '')) == count($array)) {
             return array_keys($array);
-        } else if (count(array_keys($array, 'array_value')) == count($array)) {
+        } elseif (count(array_keys($array, 'array_value')) == count($array)) {
         }
 
         return $array;

--- a/contenido/external/wysiwyg/tinymce3/editorclass.php
+++ b/contenido/external/wysiwyg/tinymce3/editorclass.php
@@ -266,7 +266,7 @@ class cTinyMCEEditor extends cWYSIWYGEditor {
 
         if (array_key_exists("theme_advanced_styles", $this->_aSettings)) {
             $styles = $this->_aSettings["theme_advanced_styles"];
-        } else if (array_key_exists("tinymce-styles", $this->_aSettings)) {
+        } elseif (array_key_exists("tinymce-styles", $this->_aSettings)) {
             $styles = $this->_aSettings["tinymce-styles"];
         }
 
@@ -290,7 +290,7 @@ class cTinyMCEEditor extends cWYSIWYGEditor {
         if ($lists == "") {
             if (array_key_exists("contenido_lists", $this->_aSettings)) {
                 $lists = $this->_aSettings["contenido_lists"];
-            } else if (array_key_exists("tinymce-lists", $this->_aSettings)) {
+            } elseif (array_key_exists("tinymce-lists", $this->_aSettings)) {
                 $lists = $this->_aSettings["tinymce-lists"];
             }
         }

--- a/contenido/external/wysiwyg/tinymce4/tinymce/js/tinymce/tinymce.gzip.php
+++ b/contenido/external/wysiwyg/tinymce4/tinymce/js/tinymce/tinymce.gzip.php
@@ -169,7 +169,7 @@ class TinyMCE_Compressor {
 
 			if ($this->settings["source"] && file_exists($file . ".js")) {
 				$file .= ".js";
-			} else if (file_exists($file . ".min.js"))  {
+			} elseif (file_exists($file . ".min.js"))  {
 				$file .= ".min.js";
 			} else {
 				$file = "";

--- a/contenido/includes/frontend/include.front_content.php
+++ b/contenido/includes/frontend/include.front_content.php
@@ -244,7 +244,7 @@ if ($idcatart) {
         $idcat = $oCatArt->get('idcat');
         $idart = $oCatArt->get('idart');
     }
-} else if (!$idart) {
+} elseif (!$idart) {
     if (!$idcat) {
         // Try to get caetgory and article id of first item in current
         // clients tree structure
@@ -253,10 +253,10 @@ if ($idcatart) {
         if ($oCatArt) {
             $idart = $oCatArt->get('idart');
             $idcat = $oCatArt->get('idcat');
-        } else if ($contenido) {
+        } elseif ($contenido) {
             cInclude('includes', 'functions.i18n.php');
             die(i18n('No start article for this category'));
-        } else if ($error == 1) {
+        } elseif ($error == 1) {
             $tpl = new cTemplate();
             $tpl->set("s", "ERROR_TITLE", "Fatal error");
             $tpl->set("s", "ERROR_TEXT", "No start article for this category.");
@@ -280,11 +280,11 @@ if ($idcatart) {
 
         if ($idart != -1) {
             // donut
-        } else if ($contenido) {
+        } elseif ($contenido) {
             // Error message in backend
             cInclude('includes', 'functions.i18n.php');
             die(i18n('No start article for this category'));
-        } else if ($error == 1) {
+        } elseif ($error == 1) {
             $tpl = new cTemplate();
             $tpl->set("s", "ERROR_TITLE", "Fatal error");
             $tpl->set("s", "ERROR_TEXT", "No start article for this category.");

--- a/contenido/includes/functions.api.images.php
+++ b/contenido/includes/functions.api.images.php
@@ -453,7 +453,7 @@ function cApiImgScale($img, $maxX, $maxY, $crop = false, $expand = false, $cache
 
         $img = $cfgClient[$client]['cache']['path'] . $file;
         $deleteAfter = true;
-    } else if (!cFileHandler::exists($img)) {
+    } elseif (!cFileHandler::exists($img)) {
         // Try with upload string
         if (cFileHandler::exists($cfgClient[$client]['upl']['path'] . $img) && !is_dir($cfgClient[$client]['upl']['path'] . $img)) {
             $img = $cfgClient[$client]['upl']['path'] . $img;
@@ -674,7 +674,7 @@ function cApiImageCheckCachedImageValidity($cacheFile, $cacheTime) {
         if ($cacheTime == 0) {
             // Do not check expiration date
             return true;
-        } else if (!function_exists('md5_file')) {
+        } elseif (!function_exists('md5_file')) {
             // TODO: Explain why this is still needed ... or remove it
             if ((filemtime($cacheFile) + (60 * $cacheTime)) < time()) {
                 // Cache time expired, unlink the file
@@ -726,7 +726,7 @@ function cApiIsImageMagickAvailable() {
     // if IM is available, it contains the string "ImageMagick"
     if (!is_array($output) || count($output) == 0) {
         $imagemagickAvailable = false;
-    } else if (false === cString::findFirstPos($output[0], 'ImageMagick')) {
+    } elseif (false === cString::findFirstPos($output[0], 'ImageMagick')) {
         $imagemagickAvailable = false;
     } else {
         $imagemagickAvailable = true;

--- a/contenido/includes/functions.con.php
+++ b/contenido/includes/functions.con.php
@@ -1863,7 +1863,7 @@ function conCopyArtLang($srcidart, $dstidart, $dstidcat, $newtitle, $useCopyLabe
 
     if ($newtitle != '') {
         $title = sprintf($newtitle, $oSrcArtLang->get('title'));
-    } else if ($useCopyLabel == true) {
+    } elseif ($useCopyLabel == true) {
         $title = sprintf(i18n('%s (Copy)'), $oSrcArtLang->get('title'));
     } else {
         $title = $oSrcArtLang->get('title');

--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -184,7 +184,7 @@ function displayDatetime($timestamp = "", $date = false, $time = false) {
 
     if ($date && !$time) {
         $ret = date(getEffectiveSetting("dateformat", "date", "Y-m-d"), $timestamp);
-    } else if ($time && !$date) {
+    } elseif ($time && !$date) {
         $ret = date(getEffectiveSetting("dateformat", "time", "H:i:s"), $timestamp);
     } else {
         $ret = date(getEffectiveSetting("dateformat", "full", "Y-m-d H:i:s"), $timestamp);

--- a/contenido/includes/functions.str.php
+++ b/contenido/includes/functions.str.php
@@ -1034,7 +1034,7 @@ function strMoveSubtree($idcat, $newParentId, $newPreId = NULL, $newPostId = NUL
     if ($newParentId == -1) {
         // stop moving the category without actually moving it
         $movesubtreeidcat = 0;
-    } else if (is_null($newParentId)) {
+    } elseif (is_null($newParentId)) {
         // start moving the category withour moving it yet
         $movesubtreeidcat = $idcat;
     } else {

--- a/contenido/includes/functions.system.php
+++ b/contenido/includes/functions.system.php
@@ -38,7 +38,7 @@ function emptyLogFile() {
     if (cFileHandler::exists($filename) && is_writeable($filename)) {
         cFileHandler::truncate($filename);
         $tmp_notification = $notification->returnNotification("ok", i18n("Error log successfully cleared!"));
-    } else if (cFileHandler::exists($filename) && !is_writeable($filename)) {
+    } elseif (cFileHandler::exists($filename) && !is_writeable($filename)) {
         $tmp_notification = $notification->returnNotification("error", i18n("Can't clear error log : Access is denied!"));
     }
 

--- a/contenido/includes/include.con_content_list.php
+++ b/contenido/includes/include.con_content_list.php
@@ -165,7 +165,7 @@ if (($action == 'savecontype' || $action == 10)) {
     } else {
         $page->displayError(i18n("Permission denied"));
     }
-} else if ($action == 'deletecontype') {
+} elseif ($action == 'deletecontype') {
     if ($perm->have_perm_area_action($area, "deletecontype") || $perm->have_perm_area_action_item($area, "deletecontype", $idcat)) {
         if (isset($_REQUEST['idcontent']) && is_numeric($_REQUEST['idcontent'])) {
             $oContentColl = new cApiContentCollection();
@@ -251,7 +251,7 @@ if (($action == 'savecontype' || $action == 10)) {
     } else {
         $page->displayError(i18n("Permission denied"));
     }
-} else if ($action == 'exportrawcontent') {
+} elseif ($action == 'exportrawcontent') {
 
     /**
      * extended class to add CDATA to content
@@ -351,7 +351,7 @@ if (($action == 'savecontype' || $action == 10)) {
     ob_clean();
     echo $articleElement->asXML();
     exit;
-} else if ($action == "importrawcontent") {
+} elseif ($action == "importrawcontent") {
     // import raw data into article
     // init vars
     $error = false;
@@ -441,7 +441,7 @@ if (($action == 'savecontype' || $action == 10)) {
                                             if ($versioningState == 'simple' || $versioningState == 'disabled') {
                                                 $contentEntry = new cApiContent();
                                                 $contentEntry->loadByMany(["idtype" => $typeEntry->get("idtype"), "typeid" => $typeid, "idartlang" => $articleLanguage->get('idartlang')]);
-                                            } else if ($versioningState == 'advanced') {
+                                            } elseif ($versioningState == 'advanced') {
                                                 $contentEntryVersionCollection = new cApiContentVersionCollection();
                                                 $where = 'idtype = ' . $typeEntry->get("idtype") . ' AND typeid = ' . $typeid . ' AND idartlang = ' . $articleLanguage->get('idartlang');
                                                 $ids = $contentEntryVersionCollection->getIdsByWhereClause($where);
@@ -691,7 +691,7 @@ switch ($versioningState) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if (is_numeric($idArtLangVersion) && $articleType == 'editable') {
+            } elseif (is_numeric($idArtLangVersion) && $articleType == 'editable') {
                 $artLangVersion = new cApiArticleLanguageVersion((int)$idArtLangVersion);
                 $artLangVersion->markAsEditable('content');
                 $articleType = $versioning->getArticleType($idArtLangVersion, (int)$_REQUEST['idartlang'], $action, $selectedArticleId);
@@ -702,7 +702,7 @@ switch ($versioningState) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if ($idArtLangVersion == 'current') {
+            } elseif ($idArtLangVersion == 'current') {
                 $artLang = new cApiArticleLanguage((int)$_REQUEST['idartlang']);
                 $artLang->markAsEditable('content');
                 $articleType = $versioning->getArticleType($idArtLangVersion, (int)$_REQUEST['idartlang'], $action, $selectedArticleId);
@@ -794,7 +794,7 @@ switch ($versioningState) {
         // Create markAsCurrent Button
         if ($articleType == 'current' || $articleType == 'version') {
             $buttonTitle = i18n('Copy to draft');
-        } else if ($articleType == 'editable') {
+        } elseif ($articleType == 'editable') {
             $buttonTitle = i18n('Publish draft');
         }
         $markAsCurrentButton = new cHTMLButton('markAsCurrentButton', $buttonTitle);
@@ -973,7 +973,7 @@ if (count($result) <= 0) {
         foreach ($typeIdValue AS $typeId => $value) {
             if (($articleType == 'editable' || $articleType == 'current' && ($versioningState == 'disabled' || $versioningState == 'simple'))) {
                 $class = '';
-            } else if ($articleType == 'current' || $articleType == 'version') {
+            } elseif ($articleType == 'current' || $articleType == 'version') {
                 $class = ' noactive';
             }
             $page->set("d", "EXTRA_CLASS", $class);
@@ -1136,7 +1136,7 @@ function _processCmsTags(
                 // double escape the generated code string to avoid violating string syntax
                 // e.g. when title of cContentTypeFilelist contains a ' character
                 $tmp = str_replace('\'', '\\\'', $tmp);
-            } else if (cFileHandler::exists($typeCodeFile)) {
+            } elseif (cFileHandler::exists($typeCodeFile)) {
                 // include CMS type code
                 include($typeCodeFile);
             } elseif (!empty($_typeItem->code)) {

--- a/contenido/includes/include.con_edit_form.php
+++ b/contenido/includes/include.con_edit_form.php
@@ -88,7 +88,7 @@ switch ($versioningState) {
                     'idlang' => cRegistry::getLanguageId()
                 ]);
 
-            } else if (is_numeric($idArtLangVersion) && $articleType == 'editable') {
+            } elseif (is_numeric($idArtLangVersion) && $articleType == 'editable') {
                 // version->editable
                 $artLangVersion = new cApiArticleLanguageVersion((int) $idArtLangVersion);
                 $artLangVersion->markAsEditable('complete');
@@ -101,7 +101,7 @@ switch ($versioningState) {
                     'idlang' => cRegistry::getLanguageId()
                 ]);
 
-            } else if ($idArtLangVersion == 'current') {
+            } elseif ($idArtLangVersion == 'current') {
                 // current->editable
                 $artLang = new cApiArticleLanguage((int) $_REQUEST['idartlang']);
                 $artLang->markAsEditable('complete');
@@ -176,7 +176,7 @@ switch ($versioningState) {
         // Create markAsCurrent Button
         if ($articleType == 'current' || $articleType == 'version') {
             $buttonTitle = i18n('Copy to draft');
-        } else if ($articleType == 'editable') {
+        } elseif ($articleType == 'editable') {
             $buttonTitle = i18n('Publish draft');
         }
         $markAsCurrentButton = new cHTMLButton('markAsCurrentButton', $buttonTitle, 'copytobutton');
@@ -478,7 +478,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
 
     if (isset($_POST['onlineOne'])) {
         conMakeOnline(cRegistry::getArticleId(), cSecurity::toInteger($_POST['onlineOne']), 1);
-    } else if (isset($_POST['offlineOne'])) {
+    } elseif (isset($_POST['offlineOne'])) {
         conMakeOnline(cRegistry::getArticleId(), cSecurity::toInteger($_POST['offlineOne']), 0);
     }
 
@@ -496,7 +496,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
     $onlineValue = -1;
     if (isset($_POST['offlineAll'])) {
         $onlineValue = 0;
-    } else if (isset($_POST['onlineAll'])) {
+    } elseif (isset($_POST['onlineAll'])) {
         $onlineValue = 1;
     }
     if (isset($_POST['syncingLanguage']) && is_array($_POST['syncingLanguage']) && $onlineValue != -1) {
@@ -529,7 +529,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
         || $versioningState == 'advanced' && $articleType == 'current')  {
         $sql = 'SELECT * FROM `%s` WHERE `idart` = %d AND `idlang` = %d';
         $sql = $db->prepare($sql, $cfg["tab"]["art_lang"], $idart, $lang);
-    } else if ($action != 'con_newart' && ($selectedArticleId == 'current' || $selectedArticleId == 'editable')
+    } elseif ($action != 'con_newart' && ($selectedArticleId == 'current' || $selectedArticleId == 'editable')
         || $selectedArticleId == NULL) {
         if (is_numeric($versioning->getEditableArticleId($idartlang))) {
             $sql = 'SELECT * FROM `%s` WHERE `idartlangversion` = %d';
@@ -599,7 +599,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
 	                $disabled = '';
 	            }
 	            $page->set("s", "REASON", i18n('Save article'));
-	        } else if ((($obj = $col->checkMark("article", $tmp_idartlang)) === false || $obj->get("userid") == $auth->auth['uid']) && $tmp_locked == 1) {
+	        } elseif ((($obj = $col->checkMark("article", $tmp_idartlang)) === false || $obj->get("userid") == $auth->auth['uid']) && $tmp_locked == 1) {
 	            $col->markInUse("article", $tmp_idartlang, $sess->id, $auth->auth["uid"]);
 	            $inUse = true;
 	            $disabled = 'disabled="disabled"';

--- a/contenido/includes/include.con_editcontent.php
+++ b/contenido/includes/include.con_editcontent.php
@@ -328,7 +328,7 @@ switch ($versioningState) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if (is_numeric($_REQUEST['idArtLangVersion']) && $articleType == 'editable') {
+            } elseif (is_numeric($_REQUEST['idArtLangVersion']) && $articleType == 'editable') {
                 $artLangVersion = new cApiArticleLanguageVersion((int) $_REQUEST['idArtLangVersion']);
                 $artLangVersion->markAsEditable('content');
                 $articleType = $versioning->getArticleType(
@@ -344,7 +344,7 @@ switch ($versioningState) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if ($_REQUEST['idArtLangVersion'] == 'current') {
+            } elseif ($_REQUEST['idArtLangVersion'] == 'current') {
                 $artLang = new cApiArticleLanguage($idartlang);
                 $artLang->markAsEditable('content');
                 $articleType = $versioning->getArticleType(
@@ -426,7 +426,7 @@ switch ($versioningState) {
         // Create markAsCurrent Button
         if ($articleType == 'current' || $articleType == 'version') {
             $buttonTitle = i18n('Copy to draft');
-        } else if ($articleType == 'editable') {
+        } elseif ($articleType == 'editable') {
             $buttonTitle = i18n('Publish draft');
         }
         $markAsCurrentButton = new cHTMLButton('markAsCurrentButton', $buttonTitle);
@@ -478,10 +478,10 @@ if ($selectedArticle != NULL) {
             if ($articleType == 'editable') {
                 $editable = true;
                 $version = $selectedArticle->get('version');
-            } else if ($articleType == 'current') {
+            } elseif ($articleType == 'current') {
                 $editable = false;
                 $version = NULL;
-            } else if ($articleType == 'version') {
+            } elseif ($articleType == 'version') {
                 $editable = false;
                 $version = $selectedArticle->get('version');
             }
@@ -490,7 +490,7 @@ if ($selectedArticle != NULL) {
              if ($articleType == 'editable' || $articleType == 'current') {
                 $editable = true;
                 $version = NULL;
-            } else if ($articleType == 'version') {
+            } elseif ($articleType == 'version') {
                 $editable = false;
                 $version = $selectedArticle->get('version');
             }

--- a/contenido/includes/include.con_meta_form.php
+++ b/contenido/includes/include.con_meta_form.php
@@ -66,7 +66,7 @@ $art->loadByArticleAndLanguageId(cSecurity::toInteger($idart), cSecurity::toInte
 if ($_REQUEST['idArtLangVersion'] == NULL && $versioning->getState() == 'advanced') {
     $art = new cApiArticleLanguageVersion($versioning->getEditableArticleId($art->getField('idartlang')));
     //$art = new cApiArticleLanguageVersion($versioning->getEditableArticleId($idArtLang));
-} else if ($versioning->getState() == 'advanced' && $_REQUEST['idArtLangVersion'] != 'current'
+} elseif ($versioning->getState() == 'advanced' && $_REQUEST['idArtLangVersion'] != 'current'
     || $versioning->getState() == 'simple' && ($_REQUEST['idArtLangVersion'] != NULL
     && is_numeric ($_REQUEST['idArtLangVersion']) || is_numeric ($_REQUEST['idArtLangVersion']))) {
     $art = new cApiArticleLanguageVersion((int) $_REQUEST['idArtLangVersion']);
@@ -106,7 +106,7 @@ switch ($versioning->getState()) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if (is_numeric($_REQUEST['idArtLangVersion']) && $articleType == 'editable') {
+            } elseif (is_numeric($_REQUEST['idArtLangVersion']) && $articleType == 'editable') {
                 // version->editable
                 $artLangVersion = new cApiArticleLanguageVersion((int) $_REQUEST['idArtLangVersion']);
                 $artLangVersion->markAsEditable('meta');
@@ -118,7 +118,7 @@ switch ($versioning->getState()) {
                     'idart' => $artLangVersion->get("idart"),
                     'idlang' => cRegistry::getLanguageId()
                 ]);
-            } else if ($_REQUEST['idArtLangVersion'] == 'current') {
+            } elseif ($_REQUEST['idArtLangVersion'] == 'current') {
                 // current->editable
                 $artLang = new cApiArticleLanguage((int) $_REQUEST['idartlang']);
                 $artLang->markAsEditable('meta');
@@ -177,7 +177,7 @@ if ($art->getField('created')) {
         $tpl->set('s', 'DISABLED', ' ' . $disabled);
         $notifications[] = $notification->returnNotification('warning', i18n('This article is currently frozen and can not be edited!'));
         $tpl->set("s", "REASON", i18n('This article is currently frozen and can not be edited!'));
-    } else if ($versioning->getState() == 'advanced' && $articleType == 'editable'
+    } elseif ($versioning->getState() == 'advanced' && $articleType == 'editable'
         || $versioning->getState() == 'simple' && $articleType != 'version'
         || $versioning->getState() == 'disabled'){
         $tpl->set('s', 'DISABLED', '');
@@ -428,7 +428,7 @@ switch ($versioning->getState()) {
         // Create markAsCurrent Button
         if ($articleType == 'current' || $articleType == 'version') {
             $buttonTitle = i18n('Copy to draft');
-        } else if ($articleType == 'editable') {
+        } elseif ($articleType == 'editable') {
             $buttonTitle = i18n('Publish draft');
         }
         $markAsCurrentButton = new cHTMLButton('markAsCurrentButton', $buttonTitle, 'copytobutton');

--- a/contenido/includes/include.default_subnav.php
+++ b/contenido/includes/include.default_subnav.php
@@ -37,7 +37,7 @@ foreach ($_GET as $sTempKey => $sTempValue) {
     if (in_array($sTempKey, $aBasicParams)) {
         // Basic parameters attached
         $iCountBasicVal++;
-    } else if ((cString::getPartOfString($sTempKey, 0, 2) == 'id' || cString::getPartOfString($sTempKey, -2, 2) == 'id')
+    } elseif ((cString::getPartOfString($sTempKey, 0, 2) == 'id' || cString::getPartOfString($sTempKey, -2, 2) == 'id')
         && ((int) $sTempValue == $sTempValue                      // check integer
         || preg_match('/^[0-9a-f]{32}$/', $sTempValue)) // check md5
         )

--- a/contenido/includes/include.frontend.group_edit.php
+++ b/contenido/includes/include.frontend.group_edit.php
@@ -51,7 +51,7 @@ if ($action == "frontendgroup_create" && $perm->have_perm_area_action($area, $ac
    $sRefreshRightTopLink = "Con.multiLink('right_top', '".$sRefreshRightTopLink."')";
    $sRefreshRightTopLinkJs = '<script type="text/javascript">' . $sRefreshRightTopLink . '</script>';
    $successMessage = i18n("Created new frontend-group successfully");
-} else if ($action == "frontendgroups_user_delete" && $perm->have_perm_area_action($area, $action)) {
+} elseif ($action == "frontendgroups_user_delete" && $perm->have_perm_area_action($area, $action)) {
     $aDeleteMembers = [];
     if (!is_array($requestUserInGroup)) {
         if ($requestUserInGroup > 0) {
@@ -67,7 +67,7 @@ if ($action == "frontendgroup_create" && $perm->have_perm_area_action($area, $ac
     $successMessage = i18n("Removed user from group successfully!");
     // also save other variables
     $action = "frontendgroup_save_group";
-} else if ($action == "frontendgroup_user_add" && $perm->have_perm_area_action($area, $action)) {
+} elseif ($action == "frontendgroup_user_add" && $perm->have_perm_area_action($area, $action)) {
     if (count($requestNewMember) > 0) {
         foreach ($requestNewMember as $add) {
             $groupmembers->create($requestIdFrontendGroup, $add);
@@ -76,7 +76,7 @@ if ($action == "frontendgroup_create" && $perm->have_perm_area_action($area, $ac
     $successMessage = i18n("Added user to group successfully!");
     // also save other variables
     $action = "frontendgroup_save_group";
-} else if ($action == "frontendgroup_delete" && $perm->have_perm_area_action($area, $action)) {
+} elseif ($action == "frontendgroup_delete" && $perm->have_perm_area_action($area, $action)) {
    $fegroups->delete($requestIdFrontendGroup);
    $requestIdFrontendGroup= 0;
    $fegroup = new cApiFrontendGroup();

--- a/contenido/includes/include.frontend.left_top.php
+++ b/contenido/includes/include.frontend.left_top.php
@@ -167,7 +167,7 @@ $oActionRow = new cGuiFoldingRow($sActionUuid, i18n("Actions"), $actionLink);
 if (isset($_GET['actionrow']) && $_GET['actionrow'] == 'collapsed') {
     $oActionRow->setExpanded(false);
     $oUser->setProperty("expandstate", $sActionUuid, 'false');
-} else if (isset($_GET['actionrow']) && $_GET['actionrow'] == 'expanded') {
+} elseif (isset($_GET['actionrow']) && $_GET['actionrow'] == 'expanded') {
     $oActionRow->setExpanded(true);
     $oUser->setProperty("expandstate", $sActionUuid, 'true');
 }
@@ -201,7 +201,7 @@ $oListOptionRow->setExpanded(true);
 if (isset($_GET['filterrow']) && $_GET['filterrow'] == 'collapsed') {
     $oActionRow->setExpanded(false);
     $oUser->setProperty("expandstate", $sListOptionId, 'false');
-} else if (isset($_GET['filterrow']) && $_GET['filterrow'] == 'expanded') {
+} elseif (isset($_GET['filterrow']) && $_GET['filterrow'] == 'expanded') {
     $oActionRow->setExpanded(true);
     $oUser->setProperty("expandstate", $sListOptionId, 'true');
 }

--- a/contenido/includes/include.frontend.user_edit.php
+++ b/contenido/includes/include.frontend.user_edit.php
@@ -92,7 +92,7 @@ if (true === $feuser->isLoaded() && $feuser->get("idclient") == $client) {
 
     if ($action == "frontend_save_user" && cString::getStringLength($username) == 0) {
         $page->displayError(i18n("Username can't be empty"));
-    } else if ($action == "frontend_save_user" && cString::getStringLength($username) > 0) {
+    } elseif ($action == "frontend_save_user" && cString::getStringLength($username) > 0) {
         if (!empty($sReloadScript)) {
             $page->addScript($sReloadScript);
         }

--- a/contenido/includes/include.html_tpl_history.php
+++ b/contenido/includes/include.html_tpl_history.php
@@ -43,10 +43,10 @@ if (!$perm->have_perm_area_action($area, 'htmltpl_history_manage')) {
     $oPage->displayCriticalError(i18n('Permission denied'));
     $oPage->abortRendering();
     $oPage->render();
-} else if (!(int) $client > 0) {
+} elseif (!(int) $client > 0) {
     $oPage->abortRendering();
     $oPage->render();
-} else if (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
+} elseif (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
     $oPage->displayWarning(i18n('Versioning is not activated'));
     $oPage->abortRendering();
     $oPage->render();

--- a/contenido/includes/include.js_history.php
+++ b/contenido/includes/include.js_history.php
@@ -41,10 +41,10 @@ if (!$perm->have_perm_area_action($area, 'js_history_manage')) {
     $oPage->displayCriticalError(i18n('Permission denied'));
     $oPage->abortRendering();
     $oPage->render();
-} else if (!(int) $client > 0) {
+} elseif (!(int) $client > 0) {
     $oPage->abortRendering();
     $oPage->render();
-} else if (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
+} elseif (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
     $oPage->displayWarning(i18n('Versioning is not activated'));
     $oPage->abortRendering();
     $oPage->render();

--- a/contenido/includes/include.lang_edit.php
+++ b/contenido/includes/include.lang_edit.php
@@ -95,13 +95,13 @@ if ($action == "lang_newlanguage") {
         }
         if (true === cString::validateDateFormat(stripslashes($dateformat))) {
             $oLanguage->setProperty("dateformat", "date", stripslashes($dateformat), $targetclient);
-        } else if (false === $invalidData) {
+        } elseif (false === $invalidData) {
             $invalidData = true;
             $page->displayError(i18n("Incorrect date format"));
         }
         if (true === cString::validateDateFormat(stripslashes($timeformat))) {
             $oLanguage->setProperty("dateformat", "time", stripslashes($timeformat), $targetclient);
-        } else if (false === $invalidData) {
+        } elseif (false === $invalidData) {
             $invalidData = true;
             $page->displayError(i18n("Incorrect time format"));
         }

--- a/contenido/includes/include.lang_left_top.php
+++ b/contenido/includes/include.lang_left_top.php
@@ -49,7 +49,7 @@ $tpl->set('s', 'CLIENTSELECT', $select);
 
 if ($perm->have_perm_area_action("lang_edit", "lang_newlanguage") && $iClientcount > 0) {
     $tpl->set('s', 'NEWLANG', '<a class="addfunction" href="javascript:void(0)">' . i18n("Create language for") . '</a>');
-} else if ($iClientcount == 0) {
+} elseif ($iClientcount == 0) {
     $tpl->set('s', 'NEWLANG', i18n('No Client selected'));
 } else {
     $tpl->set('s', 'NEWLANG', '');

--- a/contenido/includes/include.lay_history.php
+++ b/contenido/includes/include.lay_history.php
@@ -44,11 +44,11 @@ if (!$perm->have_perm_area_action($area, 'lay_history_manage')) {
     $oPage->abortRendering();
     $oPage->render();
     return;
-} else if (!(int) $client > 0) {
+} elseif (!(int) $client > 0) {
     $oPage->abortRendering();
     $oPage->render();
     return;
-} else if (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
+} elseif (getEffectiveSetting('versioning', 'activated', 'false') == 'false') {
     $oPage->displayWarning(i18n("Versioning is not activated"));
     $oPage->abortRendering();
     $oPage->render();

--- a/contenido/includes/include.lay_overview.php
+++ b/contenido/includes/include.lay_overview.php
@@ -65,7 +65,7 @@ while (($layout = $oLayouts->next()) !== false) {
             $delLink  = '<a href="javascript:;" data-action="delete_layout" title="'.$delTitle.'">'
                       . '<img class="vAlignMiddle" src="'.$cfg['path']['images'].'delete.gif" title="'.$delTitle.'" alt="'.$delTitle.'"></a>';
         }
-    } else if ($hasDeletePermission && $inUse) {
+    } elseif ($hasDeletePermission && $inUse) {
         $delTitle = i18n("Layout is in use, cannot delete");
         $delLink = '<img class="vAlignMiddle" src="'.$cfg['path']['images'].'delete_inact.gif" title="'.$delTitle.'" alt="'.$delTitle.'">';
     } else {

--- a/contenido/includes/include.logs.php
+++ b/contenido/includes/include.logs.php
@@ -203,7 +203,7 @@ $todate = $oToYear->getDefault() . '-' . $oToMonth->getDefault() . '-' . $oToDay
 $limitsql = "";
 if ($limit == 1) {
     $limitsql = "";
-} else if ($limit == 0) {
+} elseif ($limit == 0) {
     $limitsql = "10";
 } else {
     $limitsql = $db->escape($limit);

--- a/contenido/includes/include.mail_log.php
+++ b/contenido/includes/include.mail_log.php
@@ -45,7 +45,7 @@ if ($action == 'mail_log_delete') {
             $mailLogSuccessCollection->deleteBy('idmail', $idmail);
         }
     }
-} else if ($action == 'mail_log_resend') {
+} elseif ($action == 'mail_log_resend') {
     $mailer = new cMailer();
     $mailer->resendMail($_REQUEST['idmailsuccess']);
 }
@@ -153,7 +153,7 @@ if ($area === 'mail_log' || $area === 'mail_log_overview') {
 
     // add the bottom bulk editing functions
     $page->appendContent(mailLogBulkEditingFunctions());
-} else if ($area === 'mail_log_detail') {
+} elseif ($area === 'mail_log_detail') {
     if (isset($_REQUEST['idmail']) && is_numeric($_REQUEST['idmail'])) {
         // construct the back button
         $link = new cHTMLLink(cRegistry::getBackendUrl() . 'main.php?area=mail_log&frame=4&contenido=' . cRegistry::getSession()->id);

--- a/contenido/includes/include.mod_overview.php
+++ b/contenido/includes/include.mod_overview.php
@@ -121,7 +121,7 @@ foreach ($allModules as $idmod => $module) {
 
         if ($sModuleError == "none") {
             $colName = $sName;
-        } else if ($sModuleError == "input" || $sModuleError == "output") {
+        } elseif ($sModuleError == "input" || $sModuleError == "output") {
             $colName = '<span class="moduleError">' . $sName . '</span>';
         } else {
             $colName = '<span class="moduleCriticalError">' . $sName . '</span>';

--- a/contenido/includes/include.mycontenido.php
+++ b/contenido/includes/include.mycontenido.php
@@ -215,9 +215,9 @@ foreach ($admins as $pos => $item) {
         $li = '<li class="welcome">';
         if ($sAdminName !== '' && $sAdminEmail !== '') {
             $li .= $sAdminName . ', ' . $sAdminEmail . '</li>';
-        } else if ($sAdminName === '' && $sAdminEmail !== '') {
+        } elseif ($sAdminName === '' && $sAdminEmail !== '') {
             $li .= $sAdminEmail . '</li>';
-        } else if ($sAdminName !== '' && $sAdminEmail === '') {
+        } elseif ($sAdminName !== '' && $sAdminEmail === '') {
             $li .= $sAdminName . '</li>';
         } else {
             $li = '';

--- a/contenido/includes/include.mycontenido_settings.php
+++ b/contenido/includes/include.mycontenido_settings.php
@@ -106,7 +106,7 @@ if ($action == "mycontenido_editself") {
 
     if ($user->store() && !$notificationDisplayed) {
         $page->displayOk(i18n("Changes saved"));
-    } else if (!$notificationDisplayed) {
+    } elseif (!$notificationDisplayed) {
         $page->displayError(i18n("An error occured while saving user info."));
     }
 }

--- a/contenido/includes/include.rights.php
+++ b/contenido/includes/include.rights.php
@@ -215,7 +215,7 @@ if ($oClientLang->isLoaded()) {
     // Account is sysadmin
     if (cString::findFirstPos($userPerms, 'sysadmin') !== false) {
         $oTpl->set('s', 'NOTIFICATION', $notification->returnMessageBox('warning', i18n("The selected user is a system administrator. A system administrator has all rights for all clients for all languages and therefore rights can't be specified in more detail."), 0));
-    } else if (cString::findFirstPos($userPerms, 'admin[') !== false) {
+    } elseif (cString::findFirstPos($userPerms, 'admin[') !== false) {
         // Account is only assigned to clients with admin rights
         $oTpl->set('s', 'NOTIFICATION', $notification->returnMessageBox('warning', i18n("The selected user is assigned to clients as admin, only. An admin has all rights for a client and therefore rights can't be specified in more detail."), 0));
     } else {

--- a/contenido/includes/include.rights_create.php
+++ b/contenido/includes/include.rights_create.php
@@ -51,10 +51,10 @@ if ($action == 'user_createuser') {
     if ($username == '') {
         $sNotification = $notification->returnNotification("warning", i18n("Username can't be empty"));
         $bError = true;
-    } else if ($username !== $cleanUsername || $realname !== $cleanRealname) {
+    } elseif ($username !== $cleanUsername || $realname !== $cleanRealname) {
         $sNotification = $notification->returnNotification("warning", i18n("Special characters in username and name are not allowed."));
         $bError = true;
-    } else if ($password == '') {
+    } elseif ($password == '') {
         $sNotification = $notification->returnNotification("warning", i18n("Password can't be empty"));
         $bError = true;
     } else {
@@ -72,7 +72,7 @@ if ($action == 'user_createuser') {
                     // User has no selected language
                     $sNotification = $notification->returnNotification("warning", i18n("Please select a language for your selected client."));
                     $bError = true;
-                } else if ($availablelanguages == false) {
+                } elseif ($availablelanguages == false) {
                     // Client has no assigned language(s)
                     $sNotification = $notification->returnNotification("warning", i18n("You can only assign users to a client with languages."));
                     $bError = true;
@@ -102,11 +102,11 @@ if ($action == 'user_createuser') {
                 // username already exists
                 $sNotification = $notification->returnNotification("warning", i18n("Username already exists"));
                 $bError = true;
-            } else if (($passCheck = cApiUser::checkPasswordMask($password)) !== cApiUser::PASS_OK) {
+            } elseif (($passCheck = cApiUser::checkPasswordMask($password)) !== cApiUser::PASS_OK) {
                 // password is not valid
                 $sNotification = $notification->returnNotification("warning", cApiUser::getErrorString($passCheck));
                 $bError = true;
-            } else if (strcmp($password, $passwordagain) == 0) {
+            } elseif (strcmp($password, $passwordagain) == 0) {
                 // username is okay, password is valid and both passwords given are
                 // equal
                 $oUserCollection = new cApiUserCollection();

--- a/contenido/includes/include.rights_overview.php
+++ b/contenido/includes/include.rights_overview.php
@@ -97,7 +97,7 @@ if ($action == 'user_edit') {
                 // User has no selected language
                 $sNotification = $notification->returnNotification("warning", i18n("Please select a language for your selected client."));
                 $bError = true;
-            } else if ($availableLanguages == false) {
+            } elseif ($availableLanguages == false) {
                 // Client has no assigned language(s)
                 $sNotification = $notification->returnNotification("warning", i18n("You can only assign users to a client with languages."));
                 $bError = true;
@@ -162,7 +162,7 @@ if ($action == 'user_edit') {
             $sNotification = $notification->returnNotification("error", i18n("Passwords don't match"));
             $bError = true;
         }
-    } else if (cString::getStringLength($password) === 0 && cString::getStringLength($passwordagain) === 0) {
+    } elseif (cString::getStringLength($password) === 0 && cString::getStringLength($passwordagain) === 0) {
         // it is okay if the password has not been changed - then the old
         // password is kept.
         $bPassOk = true;

--- a/contenido/includes/include.str_overview.php
+++ b/contenido/includes/include.str_overview.php
@@ -116,7 +116,7 @@ function buildCategorySelectRights() {
     foreach ($aCategoriesReversed as $iKeyIdCat => $aValues) {
         if ($aValues['level'] > $iLevel && $aValues['perm']) {
             $iLevel = $aValues['level'];
-        } else if ($aValues['level'] < $iLevel) {
+        } elseif ($aValues['level'] < $iLevel) {
             $iLevel = $aValues['level'];
         } else {
             if (!$aValues['perm']) {

--- a/contenido/includes/include.system_integrity.php
+++ b/contenido/includes/include.system_integrity.php
@@ -27,11 +27,11 @@ foreach ($results as $result) {
 
     if ($result["result"] == true) {
         $page->set("d", "IMAGESOURCE", $cfg['path']['contenido_fullhtml']."images/but_ok.gif");
-    } else if ($result["severity"] == cSystemtest::C_SEVERITY_WARNING) {
+    } elseif ($result["severity"] == cSystemtest::C_SEVERITY_WARNING) {
         $page->set("d", "IMAGESOURCE", $cfg['path']['contenido_fullhtml']."images/icon_warning.gif");
-    } else if ($result["severity"] == cSystemtest::C_SEVERITY_ERROR) {
+    } elseif ($result["severity"] == cSystemtest::C_SEVERITY_ERROR) {
         $page->set("d", "IMAGESOURCE", $cfg['path']['contenido_fullhtml']."images/icon_fatalerror.gif");
-    } else if ($result["severity"] == cSystemtest::C_SEVERITY_INFO) {
+    } elseif ($result["severity"] == cSystemtest::C_SEVERITY_INFO) {
         $page->set("d", "IMAGESOURCE", $cfg['path']['contenido_fullhtml']."images/info.gif");
     }
     $page->set("d", "HEADLINE", $result["headline"]);

--- a/contenido/includes/include.system_log_sysvalues.php
+++ b/contenido/includes/include.system_log_sysvalues.php
@@ -38,11 +38,11 @@ if ($action == 'deletelog' && !empty($logfile)) {
         $page->displayOk(sprintf(i18n('Logfile "%s" deleted successfully'), $logfile));
     }
     $logfile = "";
-} else if ($action == 'clearlog' && !empty($logfile)) {
+} elseif ($action == 'clearlog' && !empty($logfile)) {
     $lines = file($path . $logfile);
     $lines = array_slice($lines, cSecurity::toInteger($_REQUEST['keepLines']) * -1);
     cFileHandler::write($path . $logfile, implode('', $lines));
-} else if ($action == 'showLog' && !empty($logfile)) {
+} elseif ($action == 'showLog' && !empty($logfile)) {
     if (!empty($_REQUEST['numberOfLines'])) {
         $numberOfLines = cSecurity::toInteger($_REQUEST['numberOfLines']);
     }

--- a/contenido/includes/include.system_purge.php
+++ b/contenido/includes/include.system_purge.php
@@ -49,13 +49,13 @@ if (isset($_POST['send']) && $_POST['send'] == 'store') {
             $aClientToClear[] = $iClientId;
         }
 
-    } else if (isset($_POST['purge_clients']) && is_array($_POST['purge_clients']) && count($_POST['purge_clients']) > 0) {
+    } elseif (isset($_POST['purge_clients']) && is_array($_POST['purge_clients']) && count($_POST['purge_clients']) > 0) {
         // selected multiple clients
         foreach ($_POST['purge_clients'] as $iClientId) {
             $aClientToClear[] = (int)$iClientId;
         }
 
-    } else if (isset($_POST['purge_clients']) && (int)$_POST['purge_clients'] > 0) {
+    } elseif (isset($_POST['purge_clients']) && (int)$_POST['purge_clients'] > 0) {
         // selected single client
         $aClientToClear[] = (int)$_POST['purge_clients'];
     }

--- a/contenido/includes/include.tplcfg_edit_form.php
+++ b/contenido/includes/include.tplcfg_edit_form.php
@@ -441,7 +441,7 @@ if ($idtpl) {
 if ($area == 'str_tplcfg' || $area == 'con_tplcfg' && (int) $idart == 0) {
     $tpl->set('s', 'HEADER', i18n('Category template configuration'));
     $tpl->set('s', 'DISPLAY_HEADER', 'block');
-} else if ($area == 'con_tplcfg' && (int) $idart > 0) {
+} elseif ($area == 'con_tplcfg' && (int) $idart > 0) {
     $tpl->set('s', 'HEADER', i18n('Article template configuration'));
     $tpl->set('s', 'DISPLAY_HEADER', 'block');
 } else {

--- a/contenido/includes/include.upl_search_results.php
+++ b/contenido/includes/include.upl_search_results.php
@@ -110,7 +110,7 @@ class UploadSearchResultList extends FrontendList {
 
             if ($appendparameters == "imagebrowser" || $appendparameters == "filebrowser") {
                 $mstr = '<a href="javascript://" onclick="javascript:Con.getFrame(\'left_top\').document.getElementById(\'selectedfile\').value= \'' . $cfgClient[$client]["upl"]["frontendpath"] . $path . $data . '\'; window.returnValue=\'' . $cfgClient[$client]["upl"]["frontendpath"] . $path . $data . '\'; window.close();">' . $icon . $data . '</a>';
-            } else if ('' !== $this->_fileType) {
+            } elseif ('' !== $this->_fileType) {
                 $markLeftPane = "Con.getFrame('left_bottom').upl.click(Con.getFrame('left_bottom').document.getElementById('$path'));";
 
                 $tmp_mstr = '<a onmouseover="this.style.cursor=\'pointer\'" href="javascript:Con.multiLink(\'%s\', \'%s\', \'%s\', \'%s\');' . $markLeftPane . '">%s</a>';

--- a/contenido/includes/startup.php
+++ b/contenido/includes/startup.php
@@ -144,7 +144,7 @@ $timezoneCfg = $cfg['php_settings']['date.timezone'];
 if (!empty($timezoneCfg) && ini_get('date.timezone') !== $timezoneCfg) {
     // if the timezone setting from the cfg differs from the php.ini setting, set timezone from CFG
     date_default_timezone_set($timezoneCfg);
-} else if (empty($timezoneCfg) && (ini_get('date.timezone') === '' || ini_get('date.timezone') === false)) {
+} elseif (empty($timezoneCfg) && (ini_get('date.timezone') === '' || ini_get('date.timezone') === false)) {
     // if there are no timezone settings, set UTC timezone
     date_default_timezone_set('UTC');
 }

--- a/contenido/includes/type/action/include.con_meta_saveart.action.php
+++ b/contenido/includes/type/action/include.con_meta_saveart.action.php
@@ -120,7 +120,7 @@ if ($perm->have_perm_area_action($area, 'con_meta_edit') || $perm->have_perm_are
     if (!empty($METAmetatype) && preg_match('/^([a-zA-Z])([a-zA-Z0-9\.\:\-\_]*$)/', $METAmetatype)) {
         $metaTypeColl = new cApiMetaTypeCollection();
         $metaTypeColl->create($METAmetatype, $METAfieldtype, $METAmaxlength, $METAfieldname);
-    } else if (!empty($METAmetatype)) {
+    } elseif (!empty($METAmetatype)) {
         $validMeta = false;
     }
 

--- a/contenido/tools/mpAutoloaderClassMap/mpClassTypeFinder.php
+++ b/contenido/tools/mpAutoloaderClassMap/mpClassTypeFinder.php
@@ -352,7 +352,7 @@ class mpClassTypeFinder
                 if (preg_match($item, $path)) {
                     return true;
                 }
-            } else if (strpos($path, $item) !== false) {
+            } elseif (strpos($path, $item) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
Reason:

PSR-12 (https://www.php-fig.org/psr/psr-12/) states in section 5.1:
"The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words."

On the other hand: When autoformatting else if is treated as a nested if statement.