### PR TITLE
#343 cDebugFile issue with initial writing into debug.log.

### DIFF
--- a/contenido/classes/debug/class.debug.file.php
+++ b/contenido/classes/debug/class.debug.file.php
@@ -69,7 +69,7 @@ class cDebugFile implements cDebugInterface {
      * Opens filehandle for debug logfile.
      */
     private function __construct() {
-        global $cfg; // omfg, I know... TODO
+        $cfg = cRegistry::getConfig();
         $this->_sPathToLogs = $cfg['path']['contenido_logs'];
         $this->_sFileName = 'debug.log';
         $this->_sPathToFile = $this->_sPathToLogs . $this->_sFileName;
@@ -85,10 +85,8 @@ class cDebugFile implements cDebugInterface {
      * @throws cInvalidArgumentException
      */
     public function out($msg) {
-        if (cFileHandler::writeable($this->_sPathToFile)) {
-            $sDate = date('Y-m-d H:i:s');
-            cFileHandler::write($this->_sPathToFile, $sDate . ": " . $msg . "\n", true);
-        }
+        $sDate = date('Y-m-d H:i:s');
+        cFileHandler::write($this->_sPathToFile, $sDate . ": " . $msg . "\n", true);
     }
 
     /**
@@ -101,7 +99,7 @@ class cDebugFile implements cDebugInterface {
      * @param bool   $bExit                [optional]
      *                                     If set to true, your app will die() after output of current var
      * @throws cInvalidArgumentException
-*/
+    */
     public function show($mVariable, $sVariableDescription = '', $bExit = false) {
         if (cFileHandler::writeable($this->_sPathToFile)) {
             $sDate = date('Y-m-d H:i:s');
@@ -132,4 +130,5 @@ class cDebugFile implements cDebugInterface {
      */
     public function showAll() {
     }
+
 }


### PR DESCRIPTION
Don't use `cFileHandler::writeable()`, it prevents the debugger from creating the debug.log file initially.