### PR TITLE
#376 Add ImageMagic 7 compatibility

### DIFF
--- a/contenido/includes/functions.api.images.php
+++ b/contenido/includes/functions.api.images.php
@@ -337,7 +337,8 @@ function cApiImgScaleImageMagick($img, $maxX, $maxY, $crop = false, $expand = fa
     // Try to execute convert
     $output = [];
     $retVal = 0;
-    $program = escapeshellarg($cfg['images']['image_magick']['path'] . 'convert');
+    $convertCommand = $cfg['images']['image_magick']['command'];
+    $program = escapeshellarg($cfg['images']['image_magick']['path'] . $convertCommand);
     $source = escapeshellarg($fileName);
     $destination = escapeshellarg($cacheFile);
     $quality = cApiImgGetCompressionRate($fileType, $quality);
@@ -383,6 +384,8 @@ function cApiImageIsAnimGif($sFile) {
     $cfg = cRegistry::getConfig();
     $output = [];
     $retVal = 0;
+    // NOTE: Since ImageMagic 7 the command `magick` is used for all image processing
+    //       jobs, but `identify` still works as an symbolic link to `magick`.
     $program = escapeshellarg($cfg['images']['image_magick']['path'] . 'identify');
     $source = escapeshellarg($sFile);
 
@@ -714,7 +717,8 @@ function cApiIsImageMagickAvailable() {
     $cfg = cRegistry::getConfig();
 
     // otherwise execute the IM check
-    $program = escapeshellarg($cfg['images']['image_magick']['path'] . 'convert');
+    $convertCommand = $cfg['images']['image_magick']['command'];
+    $program = escapeshellarg($cfg['images']['image_magick']['path'] . $convertCommand);
     $output = [];
     $retVal = 0;
     @exec("'{$program}' -version", $output, $retVal);

--- a/data/config/production/config.misc.php
+++ b/data/config/production/config.misc.php
@@ -364,6 +364,13 @@ $cfg['images']['image_magick']['use'] = true;
 //       to ImageMagick.
 $cfg['images']['image_magick']['path'] = '';
 
+// (string) Optional, the command to convert images.
+// NOTE: Up to ImageMagick 6 the command 'convert' was used to convert images,
+//       this has been replaced with the command 'magick' as of ImageMagick 7,
+//       which is the new primary command for all jobs.
+//       - Use 'magick' for ImageMagick >= 7
+//       - Use 'convert' for ImageMagick <= 6
+$cfg['images']['image_magick']['command'] = 'convert';
 
 // (int) configuration of the compression rate used by the cApiImgScale functions.
 //       For JPEG/JPG compression the value will be used as it is. For PNG compression

--- a/data/config/test/config.misc.php
+++ b/data/config/test/config.misc.php
@@ -364,6 +364,13 @@ $cfg['images']['image_magick']['use'] = true;
 //       to ImageMagick.
 $cfg['images']['image_magick']['path'] = '';
 
+// (string) Optional, the command to convert images.
+// NOTE: Up to ImageMagick 6 the command 'convert' was used to convert images,
+//       this has been replaced with the command 'magick' as of ImageMagick 7,
+//       which is the new primary command for all jobs.
+//       - Use 'magick' for ImageMagick >= 7
+//       - Use 'convert' for ImageMagick <= 6
+$cfg['images']['image_magick']['command'] = 'convert';
 
 // (int) configuration of the compression rate used by the cApiImgScale functions.
 //       For JPEG/JPG compression the value will be used as it is. For PNG compression


### PR DESCRIPTION
Added new configuration `$cfg['images']['image_magick']['command']` to configure the name of the primary command to use for image processing depending on used ImageMagic version.

- The new command name `magick` should be used for ImageMagick >= 7
- The old command name `convert` should be used for ImageMagick <= 6