### PR TITLE
#444 - Don't output debug info on Ajax requests

### DIFF
--- a/contenido/classes/class.registry.php
+++ b/contenido/classes/class.registry.php
@@ -728,7 +728,7 @@ class cRegistry {
      *
      * @throws cInvalidArgumentException
      */
-    public final static function shutdown($debugShowAll = true)
+    public final static function shutdown(bool $debugShowAll = true)
     {
         if ($debugShowAll) {
             cDebug::showAll();

--- a/contenido/classes/debug/class.debug.visible.adv.php
+++ b/contenido/classes/debug/class.debug.visible.adv.php
@@ -108,12 +108,17 @@ class cDebugVisibleAdv implements cDebugInterface, Countable
 
     /**
      * Outputs all Debug items in collection to screen in a HTML Box at left top
-     * of page.
+     * of the page.
+     * No output happen in case of an Ajax request.
      *
      * @throws cInvalidArgumentException
      */
     public function showAll()
     {
+        if (cIsAjaxRequest()) {
+            return;
+        }
+
         $cfg = cRegistry::getConfig();
 
         if (!empty($this->_buffer)) {

--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -1999,3 +1999,63 @@ function cBuildBackendRenderDebugInfo(array &$cfg, $oldMemoryUsage, $includedFil
     ];
     return implode("\n", $debugInfo);
 }
+
+/**
+ * Checks if the current request is a Ajax request.
+ *
+ * @since CONTENIDO 4.10.2
+ * @return bool
+ */
+function cIsAjaxRequest(): bool
+{
+    return isset($_SERVER['HTTP_X_REQUESTED_WITH']) 
+        && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest';
+}
+
+/**
+ * Checks if the current request is a GET request.
+ *
+ * @since CONTENIDO 4.10.2
+ * @return bool
+ */
+function cIsGetRequest(): bool
+{
+    return isset($_SERVER['REQUEST_METHOD'])
+        && $_SERVER['REQUEST_METHOD'] === 'GET';
+}
+
+/**
+ * Checks if the current request is a POST request.
+ *
+ * @since CONTENIDO 4.10.2
+ * @return bool
+ */
+function cIsPostRequest(): bool
+{
+    return isset($_SERVER['REQUEST_METHOD'])
+        && $_SERVER['REQUEST_METHOD'] === 'POST';
+}
+
+/**
+ * Checks if the current request is a HEAD request.
+ *
+ * @since CONTENIDO 4.10.2
+ * @return bool
+ */
+function cIsHeadRequest(): bool
+{
+    return isset($_SERVER['REQUEST_METHOD'])
+        && $_SERVER['REQUEST_METHOD'] === 'HEAD';
+}
+
+/**
+ * Checks if the current request is a PUT request.
+ *
+ * @since CONTENIDO 4.10.2
+ * @return bool
+ */
+function cIsPutRequest(): bool
+{
+    return isset($_SERVER['REQUEST_METHOD'])
+        && $_SERVER['REQUEST_METHOD'] === 'PUT';
+}


### PR DESCRIPTION
- Check for Ajax request in `cDebugVisibleAdv->showAll()`.
- Added new functions to check for some request types/methods (Ajax, get, post, head, put).