### PR TITLE
#455 PHP Warnings in HtmlParser

### DIFF
--- a/contenido/classes/class.htmlparser.php
+++ b/contenido/classes/class.htmlparser.php
@@ -33,6 +33,7 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  */
 class HtmlParser
 {
+
     /**
      * Node type ID for elements.
      *
@@ -66,34 +67,30 @@ class HtmlParser
 
     /**
      * Field iNodeType.
-     *
      * May be one of the NODE_TYPE_* constants above.
      *
      * @var int
      */
-    protected $_NodeType;
+    protected $_NodeType = 0;
 
     /**
      * Field iNodeName.
-     *
      * For elements, it's the name of the element.
      *
      * @var string
      */
-    protected $_NodeName = "";
+    protected $_NodeName = '';
 
     /**
      * Field iNodeValue.
-     *
      * For text nodes, it's the text.
      *
      * @var string
      */
-    protected $_NodeValue = "";
+    protected $_NodeValue = '';
 
     /**
      * Field iNodeAttributes.
-     *
      * A string-indexed array containing attribute values
      * of the current node. Indexes are always lowercase.
      *
@@ -109,7 +106,7 @@ class HtmlParser
     /**
      * @var int
      */
-    protected $_HtmlTextLength;
+    protected $_HtmlTextLength = 0;
 
     /**
      * @var int
@@ -118,60 +115,83 @@ class HtmlParser
 
     /**
      * Constructor to create an instance of this class.
-     *
      * Constructs an HtmlParser instance with the HTML text given.
      *
-     * @param string $HtmlText
+     * @param string $htmlText
      */
-    public function __construct($HtmlText)
+    public function __construct($htmlText)
     {
-        $this->setHtmlText($HtmlText);
-        $this->setHtmlTextLength(cString::getStringLength($HtmlText));
+        $this->setHtmlText($htmlText);
+        if ($this->getHtmlText()) {
+            $this->setHtmlTextLength(cString::getStringLength($htmlText));
+        }
     }
 
     /**
      * Set method for HtmlText variable.
      *
      * @param string $htmlText
-     *
      * @return string
      */
-    public function setHtmlText($htmlText)
+    public function setHtmlText($htmlText): string
     {
-        return $this->_HtmlText = $htmlText;
+        if (!is_string($htmlText)) {
+            try {
+                cDeprecated('Parameter $htmlText is not of type string');
+            } catch (cInvalidArgumentException $e) {
+            }
+            return '';
+        }
+        $this->_HtmlText = $htmlText;
+        return $this->_HtmlText;
     }
 
     /**
      * Set method for HtmlTextLength variable.
      *
      * @param int $htmlTextLength
-     *
      * @return int
      */
-    public function setHtmlTextLength($htmlTextLength)
+    public function setHtmlTextLength($htmlTextLength): int
     {
-        return $this->_HtmlTextLength = $htmlTextLength;
+        try {
+            if (!is_numeric($htmlTextLength)) {
+                cDeprecated('Parameter $htmlTextLength is not numeric');
+                return 0;
+            } elseif ($htmlTextLength !== cString::getStringLength($this->getHtmlText())) {
+                cDeprecated('Parameter $htmlTextLength mismatch the length of set $htmlText');
+                return 0;
+            }
+        } catch (cInvalidArgumentException $e) {
+        }
+
+        $this->_HtmlTextLength = cSecurity::toInteger($htmlTextLength);
+
+        return $this->_HtmlTextLength;
     }
 
     /**
      * Set method for HtmlTextIndex variable.
      *
-     * @param int $HtmlTextIndex
-     *
+     * @param int $htmlTextIndex
      * @return int
      */
-    public function setHtmlTextIndex($HtmlTextIndex)
+    public function setHtmlTextIndex($htmlTextIndex): int
     {
-        return $this->_HtmlTextIndex = $HtmlTextIndex;
+        if (!is_numeric($htmlTextIndex)) {
+            cDeprecated('Parameter $htmlTextIndex is not numeric');
+            return 0;
+        }
+        $this->_HtmlTextIndex = cSecurity::toInteger($htmlTextIndex);
+
+        return $this->_HtmlTextIndex;
     }
 
     /**
      * Set method for NodeAttributes.
-     *
      * To clear this array please use _clearAttributes function.
      *
      * @param array $NodeAttributes
-     *
      * @return bool|array
      */
     public function _setNodeAttributes($NodeAttributes)
@@ -179,8 +199,9 @@ class HtmlParser
         if (!is_array($NodeAttributes)) {
             return false;
         }
+        $this->_NodeAttributes = $NodeAttributes;
 
-        return $this->_NodeAttributes = $NodeAttributes;
+        return $this->_NodeAttributes;
     }
 
     /**
@@ -188,7 +209,7 @@ class HtmlParser
      *
      * @return string
      */
-    public function getHtmlText()
+    public function getHtmlText(): string
     {
         return $this->_HtmlText;
     }
@@ -198,7 +219,7 @@ class HtmlParser
      *
      * @return int
      */
-    public function getHtmlTextLength()
+    public function getHtmlTextLength(): int
     {
         return $this->_HtmlTextLength;
     }
@@ -206,9 +227,9 @@ class HtmlParser
     /**
      * Get method for _NodeType.
      *
-     * @return string
+     * @return int
      */
-    public function getNodeType()
+    public function getNodeType(): int
     {
         return $this->_NodeType;
     }
@@ -218,17 +239,17 @@ class HtmlParser
      *
      * @return string
      */
-    public function getNodeName()
+    public function getNodeName(): string
     {
         return $this->_NodeName;
     }
 
     /**
-     * Getmethod for _NodeAttributes.
+     * Get method for _NodeAttributes.
      *
      * @return array
      */
-    public function getNodeAttributesArray()
+    public function getNodeAttributesArray(): array
     {
         return $this->_NodeAttributes;
     }
@@ -240,9 +261,9 @@ class HtmlParser
      *
      * @return string
      */
-    public function getNodeAttributes($attribute)
+    public function getNodeAttributes($attribute): string
     {
-        return isset($this->_NodeAttributes[$attribute]) ? $this->_NodeAttributes[$attribute] : '';
+        return $this->_NodeAttributes[$attribute] ?? '';
     }
 
     /**
@@ -250,7 +271,7 @@ class HtmlParser
      *
      * @return int
      */
-    public function getHtmlTextIndex()
+    public function getHtmlTextIndex(): int
     {
         return $this->_HtmlTextIndex;
     }
@@ -258,11 +279,12 @@ class HtmlParser
     /**
      * Increase HtmlTextIndex.
      *
-     * @return bool
+     * @return int
      */
-    protected function increaseHtmlTextIndex()
+    protected function increaseHtmlTextIndex(): int
     {
-        return $this->_HtmlTextIndex++;
+        $this->_HtmlTextIndex++;
+        return $this->_HtmlTextIndex;
     }
 
     /**
@@ -273,7 +295,7 @@ class HtmlParser
      *
      * @return bool
      */
-    public function parse()
+    public function parse(): bool
     {
         $text = $this->_skipToElement();
         if ($text != "") {
@@ -292,19 +314,19 @@ class HtmlParser
      *
      * @return array
      */
-    protected function _clearAttributes()
+    protected function _clearAttributes(): array
     {
-        return $this->_NodeAttributes = [];
+        $this->_NodeAttributes = [];
+        return $this->_NodeAttributes;
     }
 
     /**
      * @return bool
      */
-    protected function _readTag()
+    protected function _readTag(): bool
     {
         if ($this->_currentChar() != "<") {
             $this->_NodeType = self::NODE_TYPE_DONE;
-
             return false;
         }
 
@@ -377,18 +399,17 @@ class HtmlParser
 
     /**
      * @param string $name
-     *
-     * @return number
+     * @return int
      */
-    protected function _isValidTagIdentifier($name)
+    protected function _isValidTagIdentifier($name): int
     {
-        return preg_match('/[A-Za-z0-9]+/', $name);
+        return (int) preg_match('/[A-Za-z0-9]+/', $name);
     }
 
     /**
      * @return bool
      */
-    protected function _skipBlanksInTag()
+    protected function _skipBlanksInTag(): bool
     {
         return "" != ($this->_skipInTag([" ", "\t", "\r", "\n"]));
     }
@@ -396,7 +417,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _skipToBlanksOrEqualsInTag()
+    protected function _skipToBlanksOrEqualsInTag(): string
     {
         return $this->_skipToInTag([" ", "\t", "\r", "\n", "="]);
     }
@@ -404,7 +425,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _skipToBlanksInTag()
+    protected function _skipToBlanksInTag(): string
     {
         return $this->_skipToInTag([" ", "\t", "\r", "\n"]);
     }
@@ -412,7 +433,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _skipEqualsInTag()
+    protected function _skipEqualsInTag(): string
     {
         return $this->_skipInTag(["="]);
     }
@@ -420,7 +441,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _readValueInTag()
+    protected function _readValueInTag(): string
     {
         $ch = $this->_currentChar();
 
@@ -440,26 +461,25 @@ class HtmlParser
     }
 
     /**
-     * @return number|string
+     * @return int|string
      */
     protected function _currentChar()
     {
         if ($this->getHtmlTextIndex() >= $this->getHtmlTextLength()) {
             return -1;
         }
-        $HtmlText = $this->getHtmlText();
+        $htmlText = $this->getHtmlText();
 
-        return cString::getPartOfString($HtmlText, $this->getHtmlTextIndex(), 1);
+        return cString::getPartOfString($htmlText, $this->getHtmlTextIndex(), 1);
     }
 
     /**
      * @return bool
      */
-    protected function _moveNext()
+    protected function _moveNext(): bool
     {
         if ($this->getHtmlTextIndex() < $this->getHtmlTextLength()) {
             $this->increaseHtmlTextIndex();
-
             return true;
         } else {
             return false;
@@ -469,7 +489,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _skipEndOfTag()
+    protected function _skipEndOfTag(): string
     {
         $sb = "";
         if (($ch = $this->_currentChar()) !== -1) {
@@ -489,7 +509,7 @@ class HtmlParser
      *
      * @return string
      */
-    protected function _skipInTag($chars)
+    protected function _skipInTag($chars): string
     {
         $sb = "";
         while (($ch = $this->_currentChar()) !== -1) {
@@ -519,7 +539,7 @@ class HtmlParser
      *
      * @return string
      */
-    protected function _skipToInTag($chars)
+    protected function _skipToInTag($chars): string
     {
         $sb = "";
         while (($ch = $this->_currentChar()) !== -1) {
@@ -545,7 +565,7 @@ class HtmlParser
     /**
      * @return string
      */
-    protected function _skipToElement()
+    protected function _skipToElement(): string
     {
         $sb = "";
         while (($ch = $this->_currentChar()) !== -1) {
@@ -568,17 +588,19 @@ class HtmlParser
      *
      * @return string
      */
-    protected function _skipToStringInTag($needle)
+    protected function _skipToStringInTag($needle): string
     {
         $pos = cString::findFirstPos($this->getHtmlText(), $needle, $this->getHtmlTextIndex());
         if ($pos === false) {
             return "";
         }
         $top = $pos + cString::getStringLength($needle);
-        $retvalue =
-            cString::getPartOfString($this->getHtmlText(), $this->getHtmlTextIndex(), $top - $this->getHtmlTextIndex());
+        $retValue = cString::getPartOfString(
+            $this->getHtmlText(), $this->getHtmlTextIndex(), $top - $this->getHtmlTextIndex()
+        );
         $this->setHtmlTextIndex($top);
 
-        return $retvalue;
+        return $retValue;
     }
+
 }

--- a/contenido/classes/class.htmlvalidator.php
+++ b/contenido/classes/class.htmlvalidator.php
@@ -22,37 +22,50 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
  */
 class cHTMLValidator
 {
+
     /**
      * @var array
      */
     protected $_doubleTags = [
-        "form",
-        "head",
-        "body",
-        "html",
-        "td",
-        "tr",
-        "table",
-        "a",
-        "tbody",
-        "title",
-        "container",
-        "span",
-        "div",
+        'form',
+        'head',
+        'body',
+        'html',
+        'td',
+        'tr',
+        'table',
+        'a',
+        'tbody',
+        'title',
+        'container',
+        'span',
+        'div',
     ];
 
     /**
      * @var array
+     * @deprecated [2024-02-11] Since 4.10.2, use {@see cHTMLValidator::getMissingNodes()} instead
      */
     public $missingNodes = [];
 
     /**
      * @var array
+     * @deprecated [2024-02-11] Since 4.10.2, use {@see cHTMLValidator::getMissingTags()} instead
      */
     public $missingTags = [];
 
     /**
-     * @deprecated not used anymore
+     * @var array
+     */
+    protected $_missingNodes = [];
+
+    /**
+     * @var array
+     */
+    protected $_missingTags = [];
+
+    /**
+     * @deprecated [2019-10-30] not used anymore
      * @var string
      */
     public $iNodeName;
@@ -82,10 +95,154 @@ class cHTMLValidator
      */
     public function validate($html)
     {
-        $nestingLevel = 0;
+        if (!is_string($html)) {
+            try {
+                cDeprecated('Parameter $html is not of type string');
+            } catch (cInvalidArgumentException $e) {
+            }
+            return;
+        }
+
+        $this->_reset();
 
         // Clean up HTML first from any PHP scripts, and clean up line breaks
         $this->_html = $this->_cleanHTML($html);
+
+        $this->_parseHTML();
+
+        // Collect all missing nodes and tags
+        foreach ($this->_nestingLevel as $key => $value) {
+            // One or more missing tags found
+            if ($value > 0) {
+                // Step through all missing tags
+                for ($i = 0; $i < $value; $i++) {
+                    $node = $this->_nestingNodes[$key][$i];
+
+                    list($line, $char) = $this->_getLineAndCharPos($node['char']);
+                    $this->_missingNodes[] = [
+                        'tag' => $key,
+                        'id' => $node['id'],
+                        'name' => $node['name'],
+                        'line' => $line,
+                        'char' => $char,
+                    ];
+
+                    $this->_missingTags[$line][$char] = true;
+                }
+            }
+        }
+
+        // Fallback in case the old public properties are still accessed somewhere
+        $this->missingTags = $this->_missingTags;
+        $this->missingNodes = $this->_missingNodes;
+    }
+
+    /**
+     * @param string $tag
+     * @return bool
+     */
+    public function tagExists($tag): bool
+    {
+        return in_array($tag, $this->_existingTags);
+    }
+
+    /**
+     * @return array
+     * @since CONTENIDO 4.10.2
+     */
+    public function getMissingNodes(): array
+    {
+        return $this->_missingNodes;
+    }
+
+    /**
+     * @return array
+     * @since CONTENIDO 4.10.2
+     */
+    public function getMissingTags(): array
+    {
+        return $this->_missingTags;
+    }
+
+    /**
+     * @param string $html
+     *
+     * @return string
+     */
+    protected function _cleanHTML($html): string
+    {
+        // Remove all php code from layout
+        $resultingHTML = preg_replace('/<\?(php)?((.)|(\s))*?\?>/i', '', $html);
+
+        // We respect only \n, but we need to take care of windows (\n\r) and other systems (\r)
+        $resultingHTML = str_replace("\r\n", "\n", $resultingHTML);
+        return str_replace("\r", "\n", $resultingHTML);
+    }
+
+    /**
+     * @return string
+     * @deprecated not used anymore
+     */
+    protected function _returnErrorMap(): string
+    {
+        $html = '<pre>';
+
+        $chunks = explode("\n", $this->_html);
+
+        foreach ($chunks as $key => $value) {
+            $html .= ($key + 1) . ' ';
+
+            for ($i = 0; $i < cString::getStringLength($value); $i++) {
+                $char = cString::getPartOfString($value, $i, 1);
+
+                if (is_array($this->_missingTags[$key + 1])) {
+                    if (array_key_exists($i + 2, $this->_missingTags[$key + 1])) {
+                        $html .= '<u><b>' . conHtmlSpecialChars($char) . '</b></u>';
+                    } else {
+                        $html .= conHtmlSpecialChars($char);
+                    }
+                } else {
+                    $html .= conHtmlSpecialChars($char);
+                }
+            }
+
+            $html .= '<br>';
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param int $charpos
+     * @return array
+     */
+    protected function _getLineAndCharPos($charpos): array
+    {
+        $mangled = cString::getPartOfString($this->_html, 0, $charpos);
+        $line = cString::countSubstring($mangled, "\n") + 1;
+        $char = $charpos - cString::findLastPos($mangled, "\n");
+
+        return [$line, $char];
+    }
+
+    /**
+     * Resets instance properties.
+     *
+     * @return void
+     */
+    protected function _reset()
+    {
+        $this->_missingNodes = [];
+        $this->_missingTags = [];
+        $this->_html = '';
+        $this->_nestingLevel = [];
+        $this->_nestingNodes = [];
+        $this->_existingTags = [];
+    }
+
+    protected function _parseHTML()
+    {
+        $nestingLevel = 0;
 
         $htmlParser = new HtmlParser($this->_html);
 
@@ -95,12 +252,13 @@ class cHTMLValidator
 
             // Check if we found a double tag
             if (in_array($nodeName, $this->_doubleTags)) {
-                if (!array_key_exists($nodeName, $this->_nestingLevel)) {
+                if (!isset($this->_nestingLevel[$nodeName])) {
                     $this->_nestingLevel[$nodeName] = 0;
                 }
+                $nestingLevelIndex = intval($this->_nestingLevel[$nodeName]);
 
-                if (!array_key_exists($nodeName, $this->_nestingNodes)) {
-                    $this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])] = [];
+                if (!isset($this->_nestingNodes[$nodeName][$nestingLevelIndex])) {
+                    $this->_nestingNodes[$nodeName][$nestingLevelIndex] = [];
                 }
 
                 // Check if it's a start tag
@@ -108,10 +266,12 @@ class cHTMLValidator
                     // Push the current element to the stack, remember ID and Name, if possible
                     $nestingLevel++;
 
-                    $this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])]["name"] = $htmlParser->getNodeAttributes('name');
-                    $this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])]["id"] = $htmlParser->getNodeAttributes('id');
-                    $this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])]["level"] = $nestingLevel;
-                    $this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])]["char"] = $htmlParser->getHtmlTextIndex();
+                    $this->_nestingNodes[$nodeName][$nestingLevelIndex] = [
+                        'name' => $htmlParser->getNodeAttributes('name'),
+                        'id' => $htmlParser->getNodeAttributes('id'),
+                        'level' => $nestingLevel,
+                        'char' => $htmlParser->getHtmlTextIndex(),
+                    ];
                     $this->_nestingLevel[$nodeName]++;
                 }
 
@@ -122,7 +282,7 @@ class cHTMLValidator
                         $this->_nestingLevel[$nodeName]--;
 
                         // TODO check for the wrong nesting level
-                        // if ($this->_nestingNodes[$nodeName][intval($this->_nestingLevel[$nodeName])]["level"] != $nestingLevel) {
+                        // if ($this->_nestingNodes[$nodeName][$nestingLevelIndex]["level"] != $nestingLevel) {
                         // }
 
                         $nestingLevel--;
@@ -130,104 +290,6 @@ class cHTMLValidator
                 }
             }
         }
-
-        // missingNodes should be an empty array by default
-        $this->missingNodes = [];
-
-        // Collect all missing nodes
-        foreach ($this->_nestingLevel as $key => $value) {
-            // One or more missing tags found
-            if ($value > 0) {
-                // Step trough all missing tags
-                for ($i = 0; $i < $value; $i++) {
-                    $node = $this->_nestingNodes[$key][$i];
-
-                    list($line, $char) = $this->_getLineAndCharPos($node["char"]);
-                    $this->missingNodes[] = [
-                        "tag" => $key,
-                        "id" => $node["id"],
-                        "name" => $node["name"],
-                        "line" => $line,
-                        "char" => $char,
-                    ];
-
-                    $this->missingTags[$line][$char] = true;
-                }
-            }
-        }
     }
 
-    /**
-     * @param string $tag
-     *
-     * @return bool
-     */
-    public function tagExists($tag)
-    {
-        return in_array($tag, $this->_existingTags);
-    }
-
-    /**
-     * @param string $html
-     *
-     * @return mixed
-     */
-    protected function _cleanHTML($html)
-    {
-        // remove all php code from layout
-        $resultingHTML = preg_replace('/<\?(php)?((.)|(\s))*?\?>/i', '', $html);
-
-        // We respect only \n, but we need to take care of windows (\n\r) and other systems (\r)
-        $resultingHTML = str_replace("\r\n", "\n", $resultingHTML);
-        $resultingHTML = str_replace("\r", "\n", $resultingHTML);
-
-        return $resultingHTML;
-    }
-
-    /**
-     * @return string
-     * @deprecated not used anymore
-     */
-    protected function _returnErrorMap()
-    {
-        $html = "<pre>";
-
-        $chunks = explode("\n", $this->_html);
-
-        foreach ($chunks as $key => $value) {
-            $html .= ($key + 1) . " ";
-
-            for ($i = 0; $i < cString::getStringLength($value); $i++) {
-                $char = cString::getPartOfString($value, $i, 1);
-
-                if (is_array($this->missingTags[$key + 1])) {
-                    if (array_key_exists($i + 2, $this->missingTags[$key + 1])) {
-                        $html .= "<u><b>" . conHtmlSpecialChars($char) . "</b></u>";
-                    } else {
-                        $html .= conHtmlSpecialChars($char);
-                    }
-                } else {
-                    $html .= conHtmlSpecialChars($char);
-                }
-            }
-
-            $html .= "<br>";
-        }
-
-        return $html;
-    }
-
-    /**
-     * @param int $charpos
-     *
-     * @return array
-     */
-    protected function _getLineAndCharPos($charpos)
-    {
-        $mangled = cString::getPartOfString($this->_html, 0, $charpos);
-        $line = cString::countSubstring($mangled, "\n") + 1;
-        $char = $charpos - cString::findLastPos($mangled, "\n");
-
-        return [$line, $char];
-    }
 }

--- a/contenido/includes/functions.tpl.php
+++ b/contenido/includes/functions.tpl.php
@@ -28,12 +28,8 @@ cInclude("includes", "functions.con.php");
  * @param int $idlay
  * @param int[]|null $c Array of container id (key) and set module ids (value)
  * @param mixed|int $default 1 if template is defined as standard template
- *
- * @return number|mixed <mixed, bool, multitype:>
- *
- * @throws cDbException
- * @throws cException
- * @throws cInvalidArgumentException
+ * @return int|mixed The given $idtpl or -1
+ * @throws cDbException|cException|cInvalidArgumentException
  */
 function tplEditTemplate($changelayout, $idtpl, $name, $description, $idlay, $c, $default)
 {
@@ -135,9 +131,7 @@ function tplEditTemplate($changelayout, $idtpl, $name, $description, $idlay, $c,
  *
  * @param int $idtpl
  *         ID of the template to duplicate
- *
- * @throws cDbException
- * @throws cInvalidArgumentException
+ * @throws cDbException|cInvalidArgumentException|cException
  */
 function tplDeleteTemplate($idtpl)
 {
@@ -170,13 +164,11 @@ function tplDeleteTemplate($idtpl)
  * Browse a specific layout for containers
  *
  * @param $idlay
- *
  * @return string
  *         &-separated string of all containers
- *
- * @throws cInvalidArgumentException
+ * @throws cInvalidArgumentException|cDbException
  */
-function tplBrowseLayoutForContainers($idlay)
+function tplBrowseLayoutForContainers($idlay): string
 {
     global $containerinf;
 
@@ -224,12 +216,10 @@ function tplBrowseLayoutForContainers($idlay)
  * the list of found container numbers.
  *
  * @param int $idlay
- *
  * @return array
- *
- * @throws cInvalidArgumentException
+ * @throws cInvalidArgumentException|cDbException
  */
-function tplGetContainerNumbersInLayout($idlay)
+function tplGetContainerNumbersInLayout($idlay): array
 {
     $containerNumbers = [];
 
@@ -252,7 +242,7 @@ function tplGetContainerNumbersInLayout($idlay)
  * @return string|null
  *         Container name or null
  */
-function tplGetContainerName($idlay, $container)
+function tplGetContainerName($idlay, $container): ?string
 {
     global $containerinf;
 
@@ -275,7 +265,7 @@ function tplGetContainerName($idlay, $container)
  * @return string|null
  *         Container name or null
  */
-function tplGetContainerMode($idlay, $container)
+function tplGetContainerMode($idlay, $container): ?string
 {
     global $containerinf;
 
@@ -298,7 +288,7 @@ function tplGetContainerMode($idlay, $container)
  * @return array
  *         Allowed container types
  */
-function tplGetContainerTypes($idlay, $container)
+function tplGetContainerTypes($idlay, $container): array
 {
     global $containerinf;
 
@@ -328,7 +318,7 @@ function tplGetContainerTypes($idlay, $container)
  * @return string|null
  *         Default module name or null
  */
-function tplGetContainerDefault($idlay, $container)
+function tplGetContainerDefault($idlay, $container): ?string
 {
     global $containerinf;
 
@@ -346,8 +336,7 @@ function tplGetContainerDefault($idlay, $container)
  *
  * @param int $idlay
  *         Layout number to browse
- *
- * @throws cInvalidArgumentException
+ * @throws cInvalidArgumentException|cDbException
  */
 function tplPreparseLayout($idlay)
 {
@@ -356,18 +345,22 @@ function tplPreparseLayout($idlay)
     $cfg = cRegistry::getConfig();
     $lang = cRegistry::getLanguageId();
 
-    $layoutInFile = new cLayoutHandler($idlay, '', $cfg, $lang);
-    $code = $layoutInFile->getLayoutCode();
-
-    $parser = new HtmlParser($code);
-    $bIsBody = false;
-
     if (!is_array($containerinf)) {
         $containerinf = [];
     }
     if (!isset($containerinf[$idlay])) {
         $containerinf[$idlay] = [];
     }
+
+    $layoutInFile = new cLayoutHandler($idlay, '', $cfg, $lang);
+    $code = $layoutInFile->getLayoutCode();
+
+    if (!is_string($code)) {
+        return;
+    }
+
+    $parser = new HtmlParser($code);
+    $bIsBody = false;
 
     while ($parser->parse()) {
         if (cString::toLowerCase($parser->getNodeName()) == 'body') {
@@ -398,14 +391,11 @@ function tplPreparseLayout($idlay)
  *
  * @param int $idtpl
  *         ID of the template to duplicate
- *
  * @return int
  *         ID of the duplicated template
- * @throws cDbException
- * @throws cException
- * @throws cInvalidArgumentException
+ * @throws cDbException|cException|cInvalidArgumentException
  */
-function tplDuplicateTemplate($idtpl)
+function tplDuplicateTemplate($idtpl): int
 {
     $auth = cRegistry::getAuth();
     $idtpl = cSecurity::toInteger($idtpl);
@@ -466,13 +456,11 @@ function tplDuplicateTemplate($idtpl)
  *
  * @param int $idtpl
  *         Template ID
- *
  * @return bool
  *         is template in use
- *
  * @throws cDbException
  */
-function tplIsTemplateInUse($idtpl)
+function tplIsTemplateInUse($idtpl): bool
 {
     $db = cRegistry::getDb();
     $cfg = cRegistry::getConfig();
@@ -520,13 +508,11 @@ function tplIsTemplateInUse($idtpl)
  *
  * @param int $idtpl
  *         Template ID
- *
  * @return array
  *         category name, article name
- *
- * @throws cDbException
+ * @throws cDbException|cInvalidArgumentException
  */
-function tplGetInUsedData($idtpl)
+function tplGetInUsedData($idtpl): array
 {
     $db = cRegistry::getDb();
     $cfg = cRegistry::getConfig();
@@ -639,15 +625,11 @@ function tplGetTplAndLayoutData(int $idtpl): array
  *
  * @param int $idtplcfg
  *         Template Configuration ID
- *
  * @return int
  *         new template configuration ID
- *
- * @throws cDbException
- * @throws cException
- * @throws cInvalidArgumentException
+ * @throws cDbException|cException|cInvalidArgumentException
  */
-function tplcfgDuplicate($idtplcfg)
+function tplcfgDuplicate($idtplcfg): int
 {
     $auth = cRegistry::getAuth();
     $idtplcfg = cSecurity::toInteger($idtplcfg);
@@ -663,7 +645,7 @@ function tplcfgDuplicate($idtplcfg)
         'created' => date('Y-m-d H:i:s'),
         'lastmodified' => date('Y-m-d H:i:s'),
     ]);
-    $newidtplcfg = $newTemplateConfig->get('idtplcfg');
+    $newidtplcfg = cSecurity::toInteger($newTemplateConfig->get('idtplcfg'));
 
     // Copy container configuration from old template configuration to new template configuration
     if ($idtplcfg) {
@@ -685,15 +667,11 @@ function tplcfgDuplicate($idtplcfg)
  * - If the container mode is mandatory, insert the "default" module (if exists)
  *
  * @param int $idtpl
- *
  * @return bool
- *
- * @throws cDbException
- * @throws cInvalidArgumentException
+ * @throws cDbException|cInvalidArgumentException|cException
  * @todo Default module is only inserted in mandatory mode if container is empty. We need a better logic for handling "changes".
- *
  */
-function tplAutoFillModules($idtpl)
+function tplAutoFillModules($idtpl): bool
 {
     global $db_autofill, $containerinf, $_autoFillContainerCache;
 
@@ -785,9 +763,7 @@ function tplAutoFillModules($idtpl)
  * @param array $postData
  *         Usually $_POST
  *
- * @throws cDbException
- * @throws cException
- * @throws cInvalidArgumentException
+ * @throws cDbException|cException|cInvalidArgumentException
  */
 function tplProcessSendContainerConfiguration($idtpl, $idtplcfg, array $postData)
 {

--- a/contenido/includes/include.lay_edit_form.php
+++ b/contenido/includes/include.lay_edit_form.php
@@ -170,7 +170,7 @@ if (true === $layout->isLoaded()) {
             $msg .= "<br>";
         }
 
-        foreach ($v->missingNodes as $value) {
+        foreach ($v->getMissingNodes() as $value) {
             $idQualifier = "";
 
             $attr = [];


### PR DESCRIPTION
- Fixed PHP-warning in `HtmlParser`, reworked `HtmlParser` code.
- Updates usages of `HtmlParser`.
- Reworked `cHTMLValidator`, `cModuleTemplateHandler` and other includes.
- Added new functions `getMissingNodes()` and `getMissingTags()` in `cHTMLValidator`, marked public properties `missingNodes` and `missingTags` as deprecated.