### PR TITLE
#458 Error message is not displayed in backendedit/front_content.php

### DIFF
--- a/contenido/external/backendedit/front_content.php
+++ b/contenido/external/backendedit/front_content.php
@@ -22,13 +22,20 @@ include_once('../../includes/startup.php');
 
 $frontendPath = cRegistry::getFrontendPath();
 
-// if directory does not exist, show error message
+// If directory does not exist, show error message
 if (!is_dir($frontendPath)) {
-    $notification = new cGuiNotification();
-    $notification->displayMessageBox(cGuiNotification::LEVEL_ERROR, i18n('The given client\'s frontend directory (%s) is not a directory.', $frontendPath));
-    exit;
+    // Don't use `cGuiNotification()` or `i18n()`, we don't have an initialized  `$belang` at this stage!
+    die(sprintf(
+        'The given client\'s frontend directory (%s) is not a directory.' 
+            . (isset($client) ? '' : ' !! \$client is not set !! Check your request parameters or session'),
+        $frontendPath
+    ));
 }
 chdir($frontendPath);
+
+$cfg = cRegistry::getConfig();
+$cfgClient = cRegistry::getClientConfig();
+$client = cRegistry::getClientId();
 
 // Include the config file of the frontend to initialize client and language id
 include_once($cfgClient[$client]['config']['path'] . '/config.php');
@@ -40,5 +47,3 @@ if (file_exists($cfgClient[$client]['config']['path'] . '/config.local.php')) {
 
 // Include article view handler
 include(cRegistry::getBackendPath() . $cfg['path']['includes'] . 'frontend/include.front_content.php');
-
-?>


### PR DESCRIPTION
Fixed error because of not initialized backend language `$belang` at this early stage of the application.