### PR TITLE
#463 Plugin Newsletter: Don't use strftime formats.

### DIFF
--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -1574,7 +1574,6 @@ function buildStackString($startlevel = 2)
  * </pre>
  *
  * @SuppressWarnings docBlocks
- * @throws cInvalidArgumentException
  * @internal has variadic parameters
  */
 function cWarning()
@@ -1608,7 +1607,10 @@ function cWarning()
         $msg .= "\n";
     }
 
-    cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    try {
+        cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    } catch (cInvalidArgumentException $e) {
+    }
 
     trigger_error($message, E_USER_WARNING);
 }
@@ -1626,7 +1628,6 @@ function cWarning()
  *
  * @param string $message
  *
- * @throws cInvalidArgumentException
  * @SuppressWarnings docBlocks
  * @internal         has variadic parameters
  */
@@ -1661,7 +1662,10 @@ function cError($message)
         $msg .= "\n";
     }
 
-    cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    try {
+        cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    } catch (cInvalidArgumentException $e) {
+    }
 
     trigger_error($message, E_USER_ERROR);
 }
@@ -1673,7 +1677,6 @@ function cError($message)
  *
  * @param string $message The error message to log
  * @return void
- * @throws cInvalidArgumentException
  */
 function cLogError($message)
 {
@@ -1693,7 +1696,10 @@ function cLogError($message)
         $msg .= "\n";
     }
 
-    cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    try {
+        cFileHandler::write($cfg['path']['contenido_logs'] . 'errorlog.txt', $msg, true);
+    } catch (cInvalidArgumentException $e) {
+    }
 }
 
 /**
@@ -1701,8 +1707,6 @@ function cLogError($message)
  *
  * @param string $message
  *         Optional message (e.g. "Use function XYZ instead")
- *
- * @throws cInvalidArgumentException
  */
 function cDeprecated($message = '')
 {
@@ -1728,7 +1732,10 @@ function cDeprecated($message = '')
         $msg .= "\n";
     }
 
-    cFileHandler::write($cfg['path']['contenido_logs'] . 'deprecatedlog.txt', $msg, true);
+    try {
+        cFileHandler::write($cfg['path']['contenido_logs'] . 'deprecatedlog.txt', $msg, true);
+    } catch (cInvalidArgumentException $e) {
+    }
 }
 
 /**

--- a/contenido/plugins/newsletter/classes/class.newsletter.jobs.php
+++ b/contenido/plugins/newsletter/classes/class.newsletter.jobs.php
@@ -302,17 +302,10 @@ class NewsletterJob extends Item
             $this->set("started", date("Y-m-d H:i:s"), false);
             $this->store();
 
-            $oLanguage = new cApiLanguage($this->get("idlang"));
-            $sFormatDate = $oLanguage->getProperty("dateformat", "date");
-            $sFormatTime = $oLanguage->getProperty("dateformat", "time");
-            unset($oLanguage);
-
-            if ($sFormatDate == "") {
-                $sFormatDate = "d.m.Y";
-            }
-            if ($sFormatTime == "") {
-                $sFormatTime = "H:i";
-            }
+            /** @var PiNewsletter $plugin */
+            $plugin = cRegistry::getAppVar('pluginNewsletter');
+            $sFormatDate = $plugin->getDateFormat(cSecurity::toInteger($this->get('idlang')));
+            $sFormatTime = $plugin->getTimeFormat(cSecurity::toInteger($this->get('idlang')));
 
             // Get newsletter data
             $sFrom = $this->get("newsfrom");

--- a/contenido/plugins/newsletter/classes/class.newsletter.php
+++ b/contenido/plugins/newsletter/classes/class.newsletter.php
@@ -631,17 +631,10 @@ class Newsletter extends Item
             $sName = $sEMail;
         }
 
-        $oLanguage = new cApiLanguage($lang);
-        $sFormatDate = $oLanguage->getProperty("dateformat", "date");
-        $sFormatTime = $oLanguage->getProperty("dateformat", "time");
-        unset($oLanguage);
-
-        if ($sFormatDate == "") {
-            $sFormatDate = "%d.%m.%Y";
-        }
-        if ($sFormatTime == "") {
-            $sFormatTime = "%H:%M";
-        }
+        /** @var PiNewsletter $plugin */
+        $plugin = cRegistry::getAppVar('pluginNewsletter');
+        $sFormatDate = $plugin->getDateFormat(cSecurity::toInteger($this->get('idlang')));
+        $sFormatTime = $plugin->getTimeFormat(cSecurity::toInteger($this->get('idlang')));
 
         // Get newsletter data
         $sFrom = $this->get("newsfrom");
@@ -802,19 +795,10 @@ class Newsletter extends Item
         // Initialization
         $aMessages = [];
 
-        // Initializing cApiLanguage and get properties for dateformat
-        $oLanguage = new cApiLanguage($lang);
-        $sFormatDate = $oLanguage->getProperty("dateformat", "date");
-        $sFormatTime = $oLanguage->getProperty("dateformat", "time");
-        unset($oLanguage);
-
-        // If no date- and format defined please set standard values
-        if ($sFormatDate == "") {
-            $sFormatDate = "%d.%m.%Y";
-        }
-        if ($sFormatTime == "") {
-            $sFormatTime = "%H:%M";
-        }
+        /** @var PiNewsletter $plugin */
+        $plugin = cRegistry::getAppVar('pluginNewsletter');
+        $sFormatDate = $plugin->getDateFormat(cSecurity::toInteger($this->get('idlang')));
+        $sFormatTime = $plugin->getTimeFormat(cSecurity::toInteger($this->get('idlang')));
 
         $sPath = cRegistry::getFrontendUrl() . "front_content.php?changelang=" . $lang . "&idcatart=" . $iIDCatArt . "&";
 

--- a/contenido/plugins/newsletter/classes/class.pi.newsletter.php
+++ b/contenido/plugins/newsletter/classes/class.pi.newsletter.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file contains the Newsletter Plugin class.
+ *
+ * @since      CONTENIDO 4.10.2
+ * @package    Plugin
+ * @subpackage Newsletter
+ * @author     Murat Purc <murat@purc.de>
+ * @copyright  four for business AG <www.4fb.de>
+ * @license    https://www.contenido.org/license/LIZENZ.txt
+ * @link       https://www.4fb.de
+ * @link       https://www.contenido.org
+ */
+
+defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
+
+final class PiNewsletter
+{
+
+    /**
+     * Name of this plugin
+     * @var string
+     */
+    private $name;
+
+    /**
+     * Foldername of this plugin
+     * @var string
+     */
+    private $folderName;
+
+    /**
+     * @var array
+     */
+    private $data = [];
+
+    public function __construct()
+    {
+        $this->name = 'Newsletter';
+        $this->folderName = basename(dirname(__DIR__, 1));
+    }
+
+    /**
+     * Returns plugin name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns plugin folder name.
+     *
+     * @return string
+     */
+    public function getFolderName(): string
+    {
+        return $this->folderName;
+    }
+
+    /**
+     * Returns date format for current language.
+     * Returns the default configured date format in plugin, if no setting found.
+     *
+     * @param int $idLang
+     * @return string
+     */
+    public function getDateFormat(int $idLang): string
+    {
+        $key = 'dateFormat:' . $idLang; 
+        if (!isset($this->data[$key])) {
+            $this->initializeDateTimeFormatData($idLang);
+        }
+
+        return $this->data[$key];
+    }
+
+    /**
+     * Returns time format for current language.
+     * Returns the default configured time format in plugin, if no setting found.
+     *
+     * @param int $idLang
+     * @return string
+     */
+    public function getTimeFormat(int $idLang): string
+    {
+        $key = 'timeFormat:' . $idLang;
+        if (!isset($this->data[$key])) {
+            $this->initializeDateTimeFormatData($idLang);
+        }
+
+        return $this->data[$key];
+    }
+
+    private function initializeDateTimeFormatData(int $idLang)
+    {
+        $cfg = cRegistry::getConfig();
+
+        $dateKey = 'dateFormat:' . $idLang;
+        $timeKey = 'timeFormat:' . $idLang;
+
+        try {
+            $oLanguage = new cApiLanguage($idLang);
+            $dateFormat = $oLanguage->getProperty('dateformat', 'date');
+            $timeFormat = $oLanguage->getProperty('dateformat', 'time');
+        } catch (Throwable $e) {
+            cLogError('Could not initialize date/time format. Error: ' . $e->getMessage());
+        }
+
+        if (empty($dateFormat)) {
+            $dateFormat = $cfg['pi_newsletter']['defaultDateFormat'];
+        }
+        if (empty($timeFormat)) {
+            $timeFormat = $cfg['pi_newsletter']['defaultTimeFormat'];
+        }
+
+        $this->data[$dateKey] = $dateFormat;
+        $this->data[$timeKey] = $timeFormat;
+    }
+
+}

--- a/contenido/plugins/newsletter/includes/config.plugin.php
+++ b/contenido/plugins/newsletter/includes/config.plugin.php
@@ -16,9 +16,20 @@ defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization 
 
 global $cfg;
 
-$pluginName = basename(dirname(__DIR__, 1));
+require_once dirname(__DIR__, 1) . '/classes/class.pi.newsletter.php';
+$piNewsletter = new PiNewsletter();
+cRegistry::setAppVar('pluginNewsletter', $piNewsletter);
+
+$pluginName = $piNewsletter->getFolderName();
 
 $cfg['plugins'][$pluginName] = cRegistry::getBackendPath() . $cfg['path']['plugins'] . "$pluginName/";
+
+// Plugin configuration
+$cfg['pi_newsletter'] = [
+    'pluginName' => $pluginName,
+    'defaultDateFormat' => 'd.m.Y',
+    'defaultTimeFormat' => 'H:i',
+];
 
 // Plugin tables configuration
 $cfg['tab']['news_groupmembers'] = $cfg['sql']['sqlprefix'] . '_pi_news_groupmembers';
@@ -50,7 +61,7 @@ cAutoload::addClassmapConfig([
     'NewsletterCollection' => $pluginClassesPath . '/class.newsletter.php',
     'Newsletter' => $pluginClassesPath . '/class.newsletter.php',
     'NewsletterRecipientCollection' => $pluginClassesPath . '/class.newsletter.recipients.php',
-    'NewsletterRecipient' => $pluginClassesPath . '/class.newsletter.recipients.php',
+    'NewsletterRecipient' => $pluginClassesPath . '/class.newsletter.recipients.php'
 ]);
 
 unset($pluginName, $pluginTemplatesPath, $pluginClassesPath);

--- a/contenido/plugins/newsletter/plugin.xml
+++ b/contenido/plugins/newsletter/plugin.xml
@@ -9,7 +9,7 @@
         <copyright>four for business AG</copyright>
         <mail>info@4fb.de</mail>
         <website>https://www.4fb.de</website>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </general>
     <requirements php="7.0">
         <contenido minversion="4.10.0"/>


### PR DESCRIPTION
- Replaced deprecated strftime format against date format, and some cleanup.
- Catch errors in `cWarning()`, `cError()`, `cLogError()`, `cDeprecated()`.