### PR TITLE
Update defines.php 4.10.1 to 4.10.2-dev

### DIFF
--- a/contenido/includes/defines.php
+++ b/contenido/includes/defines.php
@@ -16,7 +16,7 @@
 defined('CON_FRAMEWORK') || die('Illegal call: Missing framework initialization - request aborted.');
 
 // CONTENIDO version
-defined('CON_VERSION') || define('CON_VERSION', '4.10.1');
+defined('CON_VERSION') || define('CON_VERSION', '4.10.2-dev');
 
 // Minimum supported PHP version
 define('CON_MIN_PHP_VERSION', '7.1');


### PR DESCRIPTION
CON_VERSION changed to 4.10.2-dev
Because it is difficult to differ the new installations if still 4.10.1 is written like the old version.