### PR TITLE
#473 Broken article specification page

### DIFF
--- a/contenido/classes/contenido/class.articlelanguage.php
+++ b/contenido/classes/contenido/class.articlelanguage.php
@@ -117,16 +117,28 @@ class cApiArticleLanguageCollection extends ItemCollection
      *
      * @param int $idart
      * @param int $idlang
-     *
      * @return int
-     *
      * @throws cDbException|cInvalidArgumentException
      */
-    public function getIdByArticleIdAndLanguageId($idart, $idlang)
+    public function getIdByArticleIdAndLanguageId($idart, $idlang): int
     {
         $sql = "SELECT `idartlang` FROM `%s` WHERE `idart` = %d AND `idlang` = %d";
         $this->db->query($sql, $this->table, $idart, $idlang);
-        return ($this->db->nextRecord()) ? $this->db->f('idartlang') : 0;
+        return $this->db->nextRecord() ? cSecurity::toInteger($this->db->f('idartlang')) : 0;
+    }
+
+    /**
+     * Resets all articles having an associated artspec.
+     *
+     * @param int $idArtSpec
+     * @return bool
+     * @throws cDbException
+     * @since CONTENIDO 4.10.2
+     */
+    public function resetArtSpec(int $idArtSpec): bool
+    {
+        $sql = 'UPDATE `%s` SET `artspec` = 0 WHERE `artspec` = %d';
+        return (bool) $this->db->query($sql, $this->table, $idArtSpec);
     }
 
 }

--- a/contenido/classes/contenido/class.articlelanguageversion.php
+++ b/contenido/classes/contenido/class.articlelanguageversion.php
@@ -107,13 +107,11 @@ class cApiArticleLanguageVersionCollection extends cApiArticleLanguageCollection
      *
      * @param int $idArtLang
      * @param int $version
-     *
      * @return int
-     *
      * @throws cDbException
      * @throws cException
      */
-    public function getIdByArticleIdAndLanguageId($idArtLang, $version)
+    public function getIdByArticleIdAndLanguageId($idArtLang, $version): int
     {
         $id = NULL;
 
@@ -126,7 +124,7 @@ class cApiArticleLanguageVersionCollection extends cApiArticleLanguageCollection
             $id = $item->get('idartlangversion');
         }
 
-        return $id ?? 0;
+        return cSecurity::toInteger($id ?? '0');
     }
 
 }

--- a/contenido/classes/genericdb/class.item.collection.php
+++ b/contenido/classes/genericdb/class.item.collection.php
@@ -1678,24 +1678,36 @@ abstract class ItemCollection extends cItemBaseAbstract
      * doesn't create an array.
      *
      * @param string $sKey
-     *         Name of the field to use for the key
+     *         Name of the field to use for the key. 
+     *         If omitted the primary key name will be used.
      * @param string|string[] $mFields
-     *         String or array
+     *         Name of the field or list of fields to return.
+     *         If omitted all fields will be returned.
      * @return array
      *         Resulting array
      * @throws cDbException|cException
      */
-    public function fetchArray($sKey, $mFields)
+    public function fetchArray(string $sKey = '', $mFields = null): array
     {
         $aResult = [];
 
+        if (empty($sKey)) {
+            $sKey = $this->getPrimaryKeyName();
+        }
+        if (!is_array($mFields) && !is_null($mFields)) {
+            $mFields = cSecurity::toString($mFields);
+        }
+
         while (($item = $this->next()) !== false) {
+            $_key = $item->get($sKey);
             if (is_array($mFields)) {
                 foreach ($mFields as $value) {
-                    $aResult[$item->get($sKey)][$value] = $item->get($value);
+                    $aResult[$_key][$value] = $item->get($value);
                 }
+            } elseif (is_null($mFields)) {
+                $aResult[$_key] = $item->toArray();
             } else {
-                $aResult[$item->get($sKey)] = $item->get($mFields);
+                $aResult[$_key] = $item->get($mFields);
             }
         }
 

--- a/contenido/includes/include.con_edit_form.php
+++ b/contenido/includes/include.con_edit_form.php
@@ -667,21 +667,24 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
     $page->set('s', 'URLNAME', i18n("Alias"));
     // end plugin Advanced Mod Rewrite
 
-    $arrArtSpecs = getArtspec();
+    $artSpecs = cGetArtSpecs(
+        cSecurity::toInteger(cRegistry::getClientId()),
+        cSecurity::toInteger(cRegistry::getLanguageId())
+    );
 
     $inputArtSortSelect = new cHTMLSelectELement("artspec", "400px");
     $inputArtSortSelect->setClass("text_medium");
-    $iAvariableSpec = 0;
-    foreach ($arrArtSpecs as $id => $value) {
-        if ($arrArtSpecs[$id]['online'] == 1) {
-            if (($arrArtSpecs[$id]['default'] == 1) && (cString::getStringLength($tmp_artspec) == 0 || $tmp_artspec == 0)) {
-                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($arrArtSpecs[$id]['artspec'], $id, true));
+    $availableSpec = 0;
+    foreach ($artSpecs as $id => $artSpecItem) {
+        if ($artSpecItem['online'] == 1) {
+            if (($artSpecItem['artspecdefault'] == 1) && (cString::getStringLength($tmp_artspec) == 0 || $tmp_artspec == 0)) {
+                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($artSpecItem['artspec'], $id, true));
             } elseif ($id == $tmp_artspec) {
-                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($arrArtSpecs[$id]['artspec'], $id, true));
+                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($artSpecItem['artspec'], $id, true));
             } else {
-                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($arrArtSpecs[$id]['artspec'], $id));
+                $inputArtSortSelect->appendOptionElement(new cHTMLOptionElement($artSpecItem['artspec'], $id));
             }
-            $iAvariableSpec++;
+            $availableSpec++;
         }
     }
     // disable select element if a non-editable version is selected
@@ -691,7 +694,7 @@ if ($perm->have_perm_area_action($area, "con_edit") || $perm->have_perm_area_act
     }
     $tmp_inputArtSort = $inputArtSortSelect->toHtml();
 
-    if ($iAvariableSpec == 0) {
+    if ($availableSpec === 0) {
         $tmp_inputArtSort = i18n("No article specifications found!");
     }
 


### PR DESCRIPTION
- Fixed empty list of article specifications.
- Fixed rendering of default article specification icon.
- Reworked article specification related functions in functions.general.php.
- Moved some logic to `cApiArticleLanguageCollection`, `cApiArticleSpecificationCollection`.
- Enhanced `ItemCollection->fetchArray()`, it uses now the set primary key value if omitted.