### PR TITLE
#476 Backend: Warning "Session deleted" after logout

### DIFF
--- a/contenido/classes/debug/class.debug.visible.adv.php
+++ b/contenido/classes/debug/class.debug.visible.adv.php
@@ -131,7 +131,7 @@ class cDebugVisibleAdv implements cDebugInterface, Countable
      */
     public function showAll()
     {
-        if (cIsAjaxRequest()) {
+        if (cIsAjaxRequest() || headers_sent()) {
             return;
         }
 

--- a/contenido/external/wysiwyg/tinymce4/contenido/ajax/class.tinymce_list.php
+++ b/contenido/external/wysiwyg/tinymce4/contenido/ajax/class.tinymce_list.php
@@ -34,13 +34,11 @@ if (!is_file($contenido_path . 'includes/startup.php')) {
 }
 include_once($contenido_path . 'includes/startup.php');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 // include editor config/combat file
 include(dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'config.php');
@@ -240,4 +238,3 @@ class cTinyMCE4List {
         echo json_encode($list);
     }
 }
-?>

--- a/contenido/frameset.php
+++ b/contenido/frameset.php
@@ -20,13 +20,11 @@ if (!defined('CON_FRAMEWORK')) {
 // CONTENIDO startup process
 include_once('./includes/startup.php');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 $area = cRegistry::getArea();
 $belang = cRegistry::getBackendLanguage();
@@ -95,5 +93,3 @@ if ((isset($menuless) && $menuless == 1)) {
 }
 
 cRegistry::shutdown();
-
-?>

--- a/contenido/frameset_left.php
+++ b/contenido/frameset_left.php
@@ -17,16 +17,21 @@ if (!defined('CON_FRAMEWORK')) {
     define('CON_FRAMEWORK', true);
 }
 
+/**
+ * @var string $belang
+ * @var array $cfg
+ * @var cSession $sess
+ * @var string $area
+ */
+
 // CONTENIDO startup process
 include_once('./includes/startup.php');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 i18nInit($cfg['path']['contenido_locale'], $belang);
 
@@ -54,5 +59,3 @@ $tpl->set('s', 'CONTENIDOPATH', cRegistry::getBackendUrl() . 'favicon.ico');
 $tpl->generate($cfg['path']['templates'] . $cfg['templates']['frameset_left']);
 
 cRegistry::shutdown();
-
-?>

--- a/contenido/frameset_right.php
+++ b/contenido/frameset_right.php
@@ -17,16 +17,21 @@ if (!defined('CON_FRAMEWORK')) {
     define('CON_FRAMEWORK', true);
 }
 
+/**
+ * @var string $belang
+ * @var array $cfg
+ * @var cSession $sess
+ * @var string $area
+ */
+
 // CONTENIDO startup process
 include_once('./includes/startup.php');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 i18nInit($cfg['path']['contenido_locale'], $belang);
 
@@ -53,5 +58,3 @@ $tpl->set('s', 'CONTENIDOPATH', cRegistry::getBackendUrl() . 'favicon.ico');
 $tpl->generate($cfg['path']['templates'] . $cfg['templates']['frameset_right']);
 
 cRegistry::shutdown();
-
-?>

--- a/contenido/includes/frontend/include.dbfs.php
+++ b/contenido/includes/frontend/include.dbfs.php
@@ -23,21 +23,17 @@ global $contenido_path, $main_dbfs_file_path, $client, $load_client, $file;
 chdir($contenido_path);
 
 if (cRegistry::getBackendSessionId()) {
-    cRegistry::bootstrap(
-        [
-            'sess' => 'cSession',
-            'auth' => 'cAuthHandlerBackend',
-            'perm' => 'cPermission',
-        ]
-    );
+    cRegistry::bootstrap([
+        'sess' => 'cSession',
+        'auth' => 'cAuthHandlerBackend',
+        'perm' => 'cPermission',
+    ]);
 } else {
-    cRegistry::bootstrap(
-        [
-            'sess' => 'cFrontendSession',
-            'auth' => 'cAuthHandlerFrontend',
-            'perm' => 'cPermission',
-        ]
-    );
+    cRegistry::bootstrap([
+        'sess' => 'cFrontendSession',
+        'auth' => 'cAuthHandlerFrontend',
+        'perm' => 'cPermission',
+    ]);
 }
 
 chdir($main_dbfs_file_path);
@@ -48,4 +44,4 @@ $client = $load_client;
 $dbfs = new cApiDbfsCollection();
 $dbfs->outputFile($file);
 
-cRegistry::shutdown();
+cRegistry::shutdown(false);

--- a/contenido/includes/frontend/include.front_content.php
+++ b/contenido/includes/frontend/include.front_content.php
@@ -693,7 +693,7 @@ if ($inUse == false && $allow == true && $view == 'edit' && ($perm->have_perm_ar
             }
 
             header('Location: ' . $redirect_url, true, $redirect_code);
-            cRegistry::shutdown();
+            cRegistry::shutdown(false);
             exit();
         } else {
             if ($cfg['debug']['codeoutput']) {
@@ -758,4 +758,3 @@ if (isset($savedlang)) {
 }
 
 cRegistry::shutdown();
-

--- a/contenido/logout.php
+++ b/contenido/logout.php
@@ -16,16 +16,21 @@ if (!defined('CON_FRAMEWORK')) {
     define('CON_FRAMEWORK', true);
 }
 
+/**
+ * @var cAuth $auth
+ * @var string $belang
+ * @var array $cfg
+ * @var cSession $sess
+ */
+
 // CONTENIDO startup process
 include_once('./includes/startup.php');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 i18nInit($cfg['path']['contenido_locale'], $belang);
 
@@ -42,9 +47,8 @@ $oActiveUser = new cApiOnlineUserCollection();
 $oActiveUser->deleteUser($iUserId);
 
 $auth->logout();
-cRegistry::shutdown();
 $sess->delete();
 
 header('Location:index.php');
 
-?>
+cRegistry::shutdown(false);

--- a/contenido/scripts/articleObject.js.php
+++ b/contenido/scripts/articleObject.js.php
@@ -21,18 +21,23 @@ if (!defined('CON_FRAMEWORK')) {
     define('CON_FRAMEWORK', true);
 }
 
+/**
+ * @var string $belang
+ * @var array $cfg
+ * @var cSession $sess
+ * @var string $area
+ */
+
 // CONTENIDO startup process
 include_once('../includes/startup.php');
 
 header('Content-Type: application/javascript');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 i18nInit($cfg['path']['contenido_locale'], $belang);
 require(cRegistry::getBackendPath() . 'includes/functions.includePluginConf.php');
@@ -40,6 +45,7 @@ require(cRegistry::getBackendPath() . 'includes/functions.includePluginConf.php'
 // it will print <script> tags which result in errors
 
 // Fetch chains
+$_cecRegistry = cApiCecRegistry::getInstance();
 $iterator = $_cecRegistry->getIterator('Contenido.Article.RegisterCustomTab');
 
 $aTabs = [];

--- a/contenido/scripts/iZoom.js.php
+++ b/contenido/scripts/iZoom.js.php
@@ -22,13 +22,11 @@ include_once('../includes/startup.php');
 
 header('Content-Type: text/javascript');
 
-cRegistry::bootstrap(
-    [
-        'sess' => 'cSession',
-        'auth' => 'cAuthHandlerBackend',
-        'perm' => 'cPermission',
-    ]
-);
+cRegistry::bootstrap([
+    'sess' => 'cSession',
+    'auth' => 'cAuthHandlerBackend',
+    'perm' => 'cPermission',
+]);
 
 $cfg = cRegistry::getConfig();
 $belang = cRegistry::getBackendLanguage();


### PR DESCRIPTION
- Disabled debug output for some pages.
- Prevented debug output if response headers already sent.
- Normalized `cRegistry::bootstrap()` syntax.
- Added PHPDoc for some pages to get rid of IDE errors because of undefined variables.