### PR TITLE
#480 - CMS-Types config use multiple same id in html overlay.

### DIFF
--- a/contenido/classes/class.registry.php
+++ b/contenido/classes/class.registry.php
@@ -566,8 +566,8 @@ class cRegistry
      * In this case a $default value can be given which will be returned if this
      * option is not defined.
      *
-     * @param string $sectionName [optional]
-     * @param string $optionName [optional]
+     * @param string|null $sectionName [optional]
+     * @param string|null $optionName [optional]
      * @param mixed $defaultValue [optional]
      * @return mixed
      */

--- a/contenido/classes/content_types/class.content.type.abstract.php
+++ b/contenido/classes/content_types/class.content.type.abstract.php
@@ -68,6 +68,13 @@ abstract class cContentTypeAbstract
     protected $_prefix = 'abstract';
 
     /**
+     * Content type id, e.g. 'cms_teaser_1'.
+     *
+     * @var string
+     */
+    protected $_contentTypeId = '';
+
+    /**
      * Whether the settings should be interpreted as plaintext or XML.
      *
      * @var string
@@ -180,6 +187,14 @@ abstract class cContentTypeAbstract
     protected $_formFields = [];
 
     /**
+     * List of form field names which are used by this content type and can have multiple values,
+     * e.g. select of type multi!
+     *
+     * @var array
+     */
+    protected $_multiFormFields = [];
+
+    /**
      * Constructor to create an instance of this class.
      *
      * Initialises class attributes with values from cRegistry.
@@ -196,6 +211,7 @@ abstract class cContentTypeAbstract
         // set props
         $this->_rawSettings = $rawSettings;
         $this->_id = $id;
+        $this->_contentTypeId = 'cms_' . $this->_prefix . '_' . $this->_id;
         $this->_contentTypes = $contentTypes;
 
         $this->_idArtLang = cRegistry::getArticleLanguageId();
@@ -658,6 +674,32 @@ abstract class cContentTypeAbstract
         return $expand;
     }
 
+    /**
+     * Returns the identifier for an element.
+     * 
+     * @param string $name
+     * @return string
+     * @since CONTENIDO 4.10.2
+     */
+    protected function _getElementId(string $name): string
+    {
+        return $this->_contentTypeId . '_' . $name;
+    }
+
+    /**
+     * Generates comma separated list of form fields names.
+     *
+     * @return string
+     * @since CONTENIDO 4.10.2
+     */
+    protected function _makeFormFieldsString(): string
+    {
+        $formFields = array_map(function ($value) {
+            return in_array($value, $this->_multiFormFields) ? $value . '[]' : $value;
+        }, $this->_formFields);
+
+        return "'" . implode("','", $formFields) . "'";
+    }
     /**
      * This functions able to use a content type object directly for output
      * See also CON-2587

--- a/contenido/classes/content_types/class.content.type.date.php
+++ b/contenido/classes/content_types/class.content.type.date.php
@@ -331,7 +331,7 @@ class cContentTypeDate extends cContentTypeAbstract
             ? date($format, $this->getSetting('date_timestamp')) : '';
         $code = new cHTMLTextbox(
             'date_timestamp_' . $this->_id, $value, '', '',
-            'date_timestamp_' . $this->_id, true, '', '', 'date_timestamp'
+            '', true, '', '', 'date_timestamp'
         );
 
         $code .= $this->_generateFormatSelect();
@@ -396,9 +396,9 @@ class cContentTypeDate extends cContentTypeAbstract
     private function _generateFormatSelect()
     {
         $formatSelect = new cHTMLSelectElement(
-            $this->_prefix . '_format_select_' . $this->_id, '',
-            $this->_prefix . '_format_select_' . $this->_id);
-        $formatSelect->setClass('con_select');
+            $this->_prefix . '_format_select_' . $this->_id, ''
+        );
+        $formatSelect->setClass('con_select date_format_select');
         $formatSelect->autoFill($this->_dateFormatsPhp);
         $phpDateFormat = conHtmlSpecialChars($this->getSetting($this->_prefix . '_format'));
         $formatSelect->setDefault($phpDateFormat);

--- a/contenido/classes/content_types/class.content.type.filelist.php
+++ b/contenido/classes/content_types/class.content.type.filelist.php
@@ -125,6 +125,9 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
             'filelist_manual_files',
             'filelist_filecount'
         ];
+        $this->_multiFormFields = [
+            'filelist_extensions',
+        ];
 
         // call parent constructor
         parent::__construct($rawSettings, $id, $contentTypes);
@@ -602,32 +605,28 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $template = new cTemplate();
         $template->set('s', 'ID', $this->_id);
         $template->set('s', 'IDARTLANG', $this->_idArtLang);
-        $template->set('s', 'FIELDS', "'" . implode("','", $this->_formFields) . "'");
+        $template->set('s', 'FIELDS', $this->_makeFormFieldsString());
 
         $templateTabs = new cTemplate();
         $templateTabs->set('s', 'PREFIX', $this->_prefix);
 
         // create code for external tab
-        $templateTabs->set('d', 'TAB_ID', 'directories');
-        $templateTabs->set('d', 'TAB_CLASS', 'directories');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_directories_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabDirectories());
         $templateTabs->next();
 
         // create code for internal tab
-        $templateTabs->set('d', 'TAB_ID', 'general');
-        $templateTabs->set('d', 'TAB_CLASS', 'general');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_general_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabGeneral());
         $templateTabs->next();
 
         // create code for file tab
-        $templateTabs->set('d', 'TAB_ID', 'filter');
-        $templateTabs->set('d', 'TAB_CLASS', 'filter');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_filter_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabFilter());
         $templateTabs->next();
 
         // create code for manual tab
-        $templateTabs->set('d', 'TAB_ID', 'manual');
-        $templateTabs->set('d', 'TAB_CLASS', 'manual');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_manual_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabManual());
         $templateTabs->next();
 
@@ -638,6 +637,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
 
         // construct the top code of the template
         $templateTop = new cTemplate();
+        $templateTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $templateTop->set('s', 'ICON', 'images/but_editlink.gif');
         $templateTop->set('s', 'ID', $this->_id);
         $templateTop->set('s', 'PREFIX', $this->_prefix);
@@ -649,10 +649,10 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
 
         // define the available tabs
         $tabMenu = [
-            'directories' => i18n('Directories'),
-            'general' => i18n('General'),
-            'filter' => i18n('Filter'),
-            'manual' => i18n('Manual')
+            'con_tab_directories' => i18n('Directories'),
+            'con_tab_general' => i18n('General'),
+            'con_tab_filter' => i18n('Filter'),
+            'con_tab_manual' => i18n('Manual')
         ];
 
         // construct the bottom code of the template
@@ -661,7 +661,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $templateBottom->set('s', 'ID', $this->_id);
         $templateBottom->set('s', 'PREFIX', $this->_prefix);
         $templateBottom->set('s', 'IDARTLANG', $this->_idArtLang);
-        $templateBottom->set('s', 'FIELDS', "'" . implode("','", $this->_formFields) . "'");
+        $templateBottom->set('s', 'FIELDS', $this->_makeFormFieldsString());
         $templateBottom->set('s', 'SETTINGS', json_encode($this->getSettings()));
         $templateBottom->set(
             's', 'JS_CLASS_SCRIPT',
@@ -699,7 +699,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
 
         $wrapperContent[] = new cHTMLParagraph(i18n('Source directory'), 'head_sub');
 
-        $directoryList = new cHTMLDiv('', 'directoryList', 'directoryList' . '_' . $this->_id);
+        $directoryList = new cHTMLDiv('', 'con_directory_list', 'con_directory_list' . '_' . $this->_id);
         $liRoot = new cHTMLListItem('root', 'root last');
         $directoryListCode = $this->generateDirectoryList($this->buildDirectoryList());
         $liRoot->setContent([
@@ -731,7 +731,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $wrapperContent[] = new cHTMLParagraph(i18n('General settings'), 'head_sub');
 
         $wrapperContent[] = new cHTMLLabel(i18n('File list title'), 'filelist_title_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('filelist_title_' . $this->_id, conHtmlSpecialChars($this->getSetting('filelist_title')), '', '', 'filelist_title_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_title', conHtmlSpecialChars($this->getSetting('filelist_title')), '', '', 'filelist_title_' . $this->_id);
         $wrapperContent[] = new cHTMLLabel(i18n('File list style'), 'filelist_style_' . $this->_id);
         $wrapperContent[] = $this->_generateStyleSelect();
         $wrapperContent[] = new cHTMLLabel(i18n('File list sort'), 'filelist_sort_' . $this->_id);
@@ -739,11 +739,19 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $wrapperContent[] = new cHTMLLabel(i18n('Sort order'), 'filelist_sortorder_' . $this->_id);
         $wrapperContent[] = $this->_generateSortOrderSelect();
         $wrapperContent[] = new cHTMLLabel(i18n('Include subdirectories?'), 'filelist_incl_subdirectories_' . $this->_id);
-        $wrapperContent[] = new cHTMLCheckbox('filelist_incl_subdirectories_' . $this->_id, '', 'filelist_incl_subdirectories_' . $this->_id, ($this->getSetting('filelist_incl_subdirectories') === 'true'));
+        $wrapperContent[] = new cHTMLCheckbox('filelist_incl_subdirectories', '', 'filelist_incl_subdirectories_' . $this->_id, ($this->getSetting('filelist_incl_subdirectories') === 'true'));
         $wrapperContent[] = new cHTMLLabel(i18n('Include meta data?'), 'filelist_incl_metadata_' . $this->_id);
-        $wrapperContent[] = new cHTMLCheckbox('filelist_incl_metadata_' . $this->_id, '', 'filelist_incl_metadata_' . $this->_id, ($this->getSetting('filelist_incl_metadata') === 'true'));
-        $div = new cHTMLDiv($this->_generateMetaDataList());
-        $div->setID('metaDataList');
+        $wrapperContent[] = new cHTMLCheckbox(
+            'filelist_incl_metadata', 
+            '', 
+            'filelist_incl_metadata_' . $this->_id, 
+            ($this->getSetting('filelist_incl_metadata') === 'true'),
+            false,
+            null,
+            '',
+            'filelist_incl_metadata'
+        );
+        $div = new cHTMLDiv($this->_generateMetaDataList(), 'filelist_meta_data_list');
         $wrapperContent[] = $div;
 
         $wrapper->setContent($wrapperContent);
@@ -759,7 +767,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
      */
     private function _generateStyleSelect()
     {
-        $htmlSelect = new cHTMLSelectElement('filelist_style_' . $this->_id, '', 'filelist_style_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('filelist_style', '', 'filelist_style_' . $this->_id);
 
         $htmlSelectOption = new cHTMLOptionElement(i18n('Default style'), 'cms_filelist_style_default.html', true);
         $htmlSelect->appendOptionElement($htmlSelectOption);
@@ -781,7 +789,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
      */
     private function _generateSortSelect()
     {
-        $htmlSelect = new cHTMLSelectElement('filelist_sort_' . $this->_id, '', 'filelist_sort_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('filelist_sort', '', 'filelist_sort_' . $this->_id);
 
         $htmlSelectOption = new cHTMLOptionElement(i18n('File name'), 'filename', true);
         $htmlSelect->appendOptionElement($htmlSelectOption);
@@ -808,7 +816,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
      */
     private function _generateSortOrderSelect()
     {
-        $htmlSelect = new cHTMLSelectElement('filelist_sortorder_' . $this->_id, '', 'filelist_sortorder_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('filelist_sortorder', '', 'filelist_sortorder_' . $this->_id);
 
         $htmlSelectOption = new cHTMLOptionElement(i18n('Ascending'), 'asc', true);
         $htmlSelect->appendOptionElement($htmlSelectOption);
@@ -870,37 +878,44 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $wrapperContent[] = new cHTMLLabel(i18n('Displayed file extensions'), 'filelist_extensions_' . $this->_id);
         $wrapperContent[] = $this->_generateExtensionSelect();
         $wrapperContent[] = '<br>';
-        $link = new cHTMLLink('#');
-        $link->setID('filelist_all_extensions');
-        $link->setContent(i18n('Select all entries'));
+        $link = new cHTMLLink('#', i18n('Select all entries'), 'filelist_all_extensions');
         $wrapperContent[] = $link;
         $wrapperContent[] = new cHTMLLabel(i18n('Ignore selection (use all)'), 'filelist_ignore_extensions_' . $this->_id, 'filelist_ignore_extensions');
-        $wrapperContent[] = new cHTMLCheckbox('filelist_ignore_extensions_' . $this->_id, '', 'filelist_ignore_extensions_' . $this->_id, ($this->getSetting('filelist_ignore_extensions') !== 'false'));
+        $wrapperContent[] = new cHTMLCheckbox(
+            'filelist_ignore_extensions', 
+            '', 
+            'filelist_ignore_extensions_' . $this->_id, 
+            ($this->getSetting('filelist_ignore_extensions') !== 'false'),
+            false,
+            null,
+            '',
+            'filelist_ignore_extensions'
+        );
 
         $wrapperContent[] = new cHTMLLabel(i18n('File size limit (in MiB)'), 'filelist_filesizefilter_from_' . $this->_id);
         $default = (!empty($this->getSetting('filelist_filesizefilter_from'))) ? $this->getSetting('filelist_filesizefilter_from') : '0';
-        $wrapperContent[] = new cHTMLTextbox('filelist_filesizefilter_from_' . $this->_id, $default, '', '', 'filelist_filesizefilter_from_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_filesizefilter_from', $default, '', '', 'filelist_filesizefilter_from_' . $this->_id);
         $wrapperContent[] = new cHTMLSpan('&nbsp;-&nbsp;');
         $default = (!empty($this->getSetting('filelist_filesizefilter_to'))) ? $this->getSetting('filelist_filesizefilter_to') : '0';
-        $wrapperContent[] = new cHTMLTextbox('filelist_filesizefilter_to_' . $this->_id, $default, '', '', 'filelist_filesizefilter_to_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_filesizefilter_to', $default, '', '', 'filelist_filesizefilter_to_' . $this->_id);
 
         $wrapperContent[] = new cHTMLLabel(i18n('Creation date limit'), 'filelist_creationdatefilter_from_' . $this->_id);
         $default = (!empty($this->getSetting('filelist_creationdatefilter_from'))) ? $this->getSetting('filelist_creationdatefilter_from') : $this->_dateFormat;
-        $wrapperContent[] = new cHTMLTextbox('filelist_creationdatefilter_from_' . $this->_id, $default, '', '', 'filelist_creationdatefilter_from_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_creationdatefilter_from', $default, '', '', 'filelist_creationdatefilter_from_' . $this->_id);
         $wrapperContent[] = new cHTMLSpan('&nbsp;-&nbsp;');
         $default = (!empty($this->getSetting('filelist_creationdatefilter_to'))) ? $this->getSetting('filelist_creationdatefilter_to') : $this->_dateFormat;
-        $wrapperContent[] = new cHTMLTextbox('filelist_creationdatefilter_to_' . $this->_id, $default, '', '', 'filelist_creationdatefilter_to_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_creationdatefilter_to', $default, '', '', 'filelist_creationdatefilter_to_' . $this->_id);
 
         $wrapperContent[] = new cHTMLLabel(i18n('Modify date limit'), 'filelist_modifydatefilter_from_' . $this->_id);
         $default = (!empty($this->getSetting('filelist_modifydatefilter_from'))) ? $this->getSetting('filelist_modifydatefilter_from') : $this->_dateFormat;
-        $wrapperContent[] = new cHTMLTextbox('filelist_modifydatefilter_from_' . $this->_id, $default, '', '', 'filelist_modifydatefilter_from_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_modifydatefilter_from', $default, '', '', 'filelist_modifydatefilter_from_' . $this->_id);
         $wrapperContent[] = new cHTMLSpan('&nbsp;-&nbsp;');
         $default = (!empty($this->getSetting('filelist_modifydatefilter_to'))) ? $this->getSetting('filelist_modifydatefilter_to') : $this->_dateFormat;
-        $wrapperContent[] = new cHTMLTextbox('filelist_modifydatefilter_to_' . $this->_id, $default, '', '', 'filelist_modifydatefilter_to_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_modifydatefilter_to', $default, '', '', 'filelist_modifydatefilter_to_' . $this->_id);
 
         $wrapperContent[] = new cHTMLLabel(i18n('File count'), 'filelist_filecount_' . $this->_id);
         $default = (!empty($this->getSetting('filelist_filecount'))) ? $this->getSetting('filelist_filecount') : '0';
-        $wrapperContent[] = new cHTMLTextbox('filelist_filecount_' . $this->_id, $default, '', '', 'filelist_filecount_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('filelist_filecount', $default, '', '', 'filelist_filecount_' . $this->_id);
 
         $wrapper->setContent($wrapperContent);
 
@@ -916,8 +931,9 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
     private function _generateExtensionSelect()
     {
         $htmlSelect = new cHTMLSelectElement(
-            'filelist_extensions_' . $this->_id, '', 'filelist_extensions_' . $this->_id,
-            ($this->getSetting('filelist_ignore_extensions') !== 'false'), '', '', 'manual'
+            'filelist_extensions', '', 'filelist_extensions_' . $this->_id,
+            ($this->getSetting('filelist_ignore_extensions') !== 'false'), '', '', 
+            'manual filelist_extensions'
         );
 
         // set other variable options manually
@@ -1001,10 +1017,17 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
 
         $wrapperContent[] = new cHTMLLabel(i18n('Use manual file list?'), 'filelist_manual_' . $this->_id);
         $wrapperContent[] = new cHTMLCheckbox(
-            'filelist_manual_' . $this->_id, '', 'filelist_manual_' . $this->_id, ($this->getSetting('filelist_manual') === 'true')
+            'filelist_manual', 
+            '', 
+            'filelist_manual_' . $this->_id, 
+            ($this->getSetting('filelist_manual') === 'true'),
+            false,
+            null,
+            '',
+            'filelist_manual'
         );
 
-        $manualDiv = new cHTMLDiv();
+        $manualDiv = new cHTMLDiv('', 'filelist_manual_filelist_setting');
         $manualDiv->setID('manual_filelist_setting');
         $manualDiv->appendStyleDefinition('display', 'none');
         $divContent = [];
@@ -1018,7 +1041,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $divContent[] = new cHTMLLabel(i18n('Directory'), '');
 
         // directory navigation
-        $directoryList = new cHTMLDiv('', 'directoryList', 'directoryList_' . $this->_id . '_manual');
+        $directoryList = new cHTMLDiv('', 'con_directory_list', 'con_directory_list_' . $this->_id . '_manual');
         $liRoot = new cHTMLListItem('root', 'last');
         $directoryListCode = $this->generateDirectoryList($this->buildDirectoryList());
         $liRoot->setContent([
@@ -1029,9 +1052,9 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         $directoryList->setContent($conStrTree);
         $divContent[] = $directoryList;
 
-        $divContent[] = new cHTMLLabel(i18n('File'), 'filelist_filename_' . $this->_id, 'filelist_filename');
+        $divContent[] = new cHTMLLabel(i18n('File'), 'filelist_filename_' . $this->_id, 'filelist_filename_label');
         $divContent[] = $this->generateFileSelect();
-        $image = new cHTMLImage(cRegistry::getBackendUrl() . 'images/but_art_new.gif');
+        $image = new cHTMLImage(cRegistry::getBackendUrl() . 'images/but_art_new.gif', 'filelist_add_file');
         $image->setAttribute('id', 'add_file');
         $image->appendStyleDefinition('cursor', 'pointer');
         $divContent[] = $image;
@@ -1071,7 +1094,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
         // }
 
         $htmlSelect = new cHTMLSelectElement(
-            'filelist_manual_files_' . $this->_id, '', 'filelist_manual_files_' . $this->_id, false, null, '', 'manual'
+            'filelist_manual_files', '', 'filelist_manual_files_' . $this->_id, false, null, '', 'manual filelist_manual_files'
         );
 
         if (is_array($this->getSetting('filelist_manual_files'))) { // More than one entry
@@ -1111,7 +1134,7 @@ class cContentTypeFilelist extends cContentTypeAbstractTabbed
     public function generateFileSelect(string $directoryPath = ''): string
     {
         $htmlSelect = new cHTMLSelectElement(
-            'filelist_filename_' . $this->_id, '', 'filelist_filename_' . $this->_id,
+            'filelist_filename', '', 'filelist_filename_' . $this->_id,
             false, null, '', 'filelist_filename'
         );
 

--- a/contenido/classes/content_types/class.content.type.imgeditor.php
+++ b/contenido/classes/content_types/class.content.type.imgeditor.php
@@ -416,6 +416,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
     {
         // construct the top code of the template
         $templateTop = new cTemplate();
+        $templateTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $templateTop->set('s', 'ICON', 'images/but_editimage.gif');
         $templateTop->set('s', 'ID', $this->_id);
         $templateTop->set('s', 'PREFIX', $this->_prefix);
@@ -426,29 +427,27 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         );
 
         $tabMenu = [
-            'directories' => i18n('Directories'),
-            'meta' => i18n('Meta'),
-            'upload' => i18n('Upload')
+            'con_tab_directories' => i18n('Directories'),
+            'con_tab_meta' => i18n('Meta'),
+            'con_tab_upload' => i18n('Upload')
         ];
 
         $templateTabs = new cTemplate();
 
         // create code for upload tab
-        $templateTabs->set('d', 'TAB_ID', 'upload');
-        $templateTabs->set('d', 'TAB_CLASS', 'upload');
-        $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabUpload());
+        $templateTabs->set('s', 'ID', $this->_id);
         $templateTabs->set('s', 'PREFIX', $this->_prefix);
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_upload_content');
+        $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabUpload());
         $templateTabs->next();
 
         // create code for directories tab
-        $templateTabs->set('d', 'TAB_ID', 'directories');
-        $templateTabs->set('d', 'TAB_CLASS', 'directories');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_directories_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabDirectories());
         $templateTabs->next();
 
         // create code for meta tab
-        $templateTabs->set('d', 'TAB_ID', 'meta');
-        $templateTabs->set('d', 'TAB_CLASS', 'meta');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_meta_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabMeta());
         $templateTabs->next();
 
@@ -505,7 +504,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         $wrapper = new cHTMLDiv();
         $wrapperContent = [];
 
-        $directoryList = new cHTMLDiv('', 'directoryList', 'directoryList' . '_' . $this->_id);
+        $directoryList = new cHTMLDiv('', 'con_directory_list', 'con_directory_list' . '_' . $this->_id);
         $liRoot = new cHTMLListItem('root', 'root');
         $aUpload = new cHTMLLink('#');
         $aUpload->setClass('on');
@@ -521,8 +520,8 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         $conStrTree = new cHTMLList('ul', 'con_str_tree', 'con_str_tree', $liRoot);
         $directoryList->setContent($conStrTree);
         $wrapperContent[] = $directoryList;
-        $wrapperContent[] = new cHTMLDiv('', 'directoryFile', 'directoryFile' . '_' . $this->_id);
-        $wrapperContent[] = new cHTMLDiv('', 'directoryShow', 'directoryShow_' . $this->_id);
+        $wrapperContent[] = new cHTMLDiv('', 'con_directory_file');
+        $wrapperContent[] = new cHTMLDiv('', 'con_directory_show');
 
         $wrapper->setContent($wrapperContent);
         return $wrapper->render();
@@ -543,22 +542,21 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         $wrapperContent = [];
 
         $imageMetaUrl = new cHTMLSpan();
-        $imageMetaUrl->setID('image_meta_url_' . $this->_id);
         $imageMetaUrl->setClass('image_meta_url');
         $wrapperContent[] = new cHTMLDiv([
             '<b>' . i18n('Selected file') . '</b>',
             $imageMetaUrl
-        ]);
-        $wrapperContent[] = new cHTMLLabel(i18n('Title'), 'image_medianame_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('image_medianame', $this->_medianame, '', '', 'image_medianame_' . $this->_id);
-        $wrapperContent[] = new cHTMLLabel(i18n('Description'), 'image_description_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextarea('image_description', $this->_description, '', '', 'image_description_' . $this->_id);
-        $wrapperContent[] = new cHTMLLabel(i18n('Keywords'), 'image_keywords_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('image_keywords', $this->_keywords, '', '', 'image_keywords_' . $this->_id);
-        $wrapperContent[] = new cHTMLLabel(i18n('Internal notes'), 'image_internal_notice_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('image_internal_notice', $this->_internalNotice, '', '', 'image_internal_notice_' . $this->_id);
-        $wrapperContent[] = new cHTMLLabel(i18n('Copyright'), 'image_copyright_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('image_copyright', $this->_copyright, '', '', 'image_copyright_' . $this->_id);
+        ], 'con_selected_file');
+        $wrapperContent[] = new cHTMLLabel(i18n('Title'), $this->_getElementId('image_medianame'));
+        $wrapperContent[] = new cHTMLTextbox('image_medianame', $this->_medianame, '', '', $this->_getElementId('image_medianame'));
+        $wrapperContent[] = new cHTMLLabel(i18n('Description'), $this->_getElementId('image_description'));
+        $wrapperContent[] = new cHTMLTextarea('image_description', $this->_description, '', '', $this->_getElementId('image_description'));
+        $wrapperContent[] = new cHTMLLabel(i18n('Keywords'), $this->_getElementId('image_keywords'));
+        $wrapperContent[] = new cHTMLTextbox('image_keywords', $this->_keywords, '', '', $this->_getElementId('image_keywords'));
+        $wrapperContent[] = new cHTMLLabel(i18n('Internal notes'), $this->_getElementId('image_internal_notice'));
+        $wrapperContent[] = new cHTMLTextbox('image_internal_notice', $this->_internalNotice, '', '', $this->_getElementId('image_internal_notice'));
+        $wrapperContent[] = new cHTMLLabel(i18n('Copyright'), $this->_getElementId('image_copyright'));
+        $wrapperContent[] = new cHTMLTextbox('image_copyright', $this->_copyright, '', '', $this->_getElementId('image_copyright'));
 
         $wrapper->setContent($wrapperContent);
         return $wrapper->render();
@@ -582,8 +580,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         $newDirForm->setAttribute('name', 'newdir');
         $newDirForm->setAttribute('method', 'post');
         $newDirForm->setAttribute('action', cRegistry::getBackendUrl() . 'main.php');
-        $caption1Span = new cHTMLSpan();
-        $caption1Span->setID('caption1');
+        $caption1Span = new cHTMLSpan('', 'con_caption con_caption1');
         $newDirHead = new cHTMLDiv([
             '<b>' . i18n('Create a directory in') . '</b>',
             $caption1Span
@@ -627,13 +624,12 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
         $action = new cHTMLHiddenField('action', 'upl_upload');
         $appendparameters = new cHTMLHiddenField('appendparameters');
         $contenido = new cHTMLHiddenField('contenido', cRegistry::getBackendSessionId());
-        $caption2Span = new cHTMLSpan();
-        $caption2Span->setID('caption2');
+        $caption2Span = new cHTMLSpan('', 'con_caption con_caption2');
         $propertiesHead = new cHTMLDiv([
             '<b>' . i18n('Path') . '</b>',
             $caption2Span
         ]);
-        $imageUpload = new cHTMLUpload('file[]', '', '', 'cms_image_m' . $this->_id, false, null, '', 'file');
+        $imageUpload = new cHTMLUpload('file[]', '', '', $this->_getElementId('file'), false, null, '', 'file');
         $imageUpload->setClass('jqueryAjaxUpload');
         $propertiesForm->setContent([
             $frame,
@@ -666,7 +662,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
      */
     public function generateFileSelect(string $directoryPath = ''): string
     {
-        $htmlSelect = new cHTMLSelectElement('image_filename', '', 'image_filename_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('image_filename', '');
         $htmlSelect->setSize(16);
         $htmlSelectOption = new cHTMLOptionElement('Kein', '', false);
         $htmlSelect->addOptionElement(0, $htmlSelectOption);

--- a/contenido/classes/content_types/class.content.type.linkeditor.php
+++ b/contenido/classes/content_types/class.content.type.linkeditor.php
@@ -251,27 +251,23 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $templateTabs->set('s', 'PREFIX', $this->_prefix);
 
         // create code for external tab
-        $templateTabs->set('d', 'TAB_ID', 'external');
-        $templateTabs->set('d', 'TAB_CLASS', 'external');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_external_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabExternal());
         $templateTabs->next();
 
         // create code for internal tab
-        $templateTabs->set('d', 'TAB_ID', 'internal');
-        $templateTabs->set('d', 'TAB_CLASS', 'internal');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_internal_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabInternal());
         $templateTabs->next();
 
         // create code for file tab
-        $templateTabs->set('d', 'TAB_ID', 'file');
-        $templateTabs->set('d', 'TAB_CLASS', 'file');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_file_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabFile());
         $templateTabs->next();
 
         // create code for basic settings "tab" - these settings are actually
         // visible any time
-        $templateTabs->set('d', 'TAB_ID', 'basic-settings');
-        $templateTabs->set('d', 'TAB_CLASS', 'basic-settings');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_basic_settings_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateBasicSettings());
         $templateTabs->next();
 
@@ -282,6 +278,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
 
         // construct the top code of the template
         $templateTop = new cTemplate();
+        $templateTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $templateTop->set('s', 'ICON', 'images/but_editlink.gif');
         $templateTop->set('s', 'ID', $this->_id);
         $templateTop->set('s', 'PREFIX', $this->_prefix);
@@ -293,9 +290,9 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
 
         // define the available tabs
         $tabMenu = [
-            'external' => i18n('External link'),
-            'internal' => i18n('Internal link'),
-            'file' => i18n('Link to a file')
+            'con_tab_external' => i18n('External link'),
+            'con_tab_internal' => i18n('Internal link'),
+            'con_tab_file' => i18n('Link to a file')
         ];
 
         // construct the bottom code of the template
@@ -340,8 +337,9 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $wrapper = new cHTMLDiv();
         $wrapperContent = [];
 
-        $wrapperContent[] = new cHTMLLabel(i18n('Href'), 'linkeditor_externallink_' . $this->_id);
-        $wrapperContent[] = new cHTMLTextbox('linkeditor_externallink_' . $this->_id, $this->getSetting('linkeditor_externallink'), '', '', 'linkeditor_externallink_' . $this->_id);
+        $id = $this->_getElementId('linkeditor_externallink');
+        $wrapperContent[] = new cHTMLLabel(i18n('Href'), $id);
+        $wrapperContent[] = new cHTMLTextbox('linkeditor_externallink_' . $this->_id, $this->getSetting('linkeditor_externallink'), '', '', $id);
 
         $wrapper->setContent($wrapperContent);
 
@@ -364,11 +362,14 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $wrapper = new cHTMLDiv();
         $wrapperContent = [];
 
-        $wrapperContent[] = new cHTMLLabel(i18n('Title'), 'linkeditor_title_' . $this->_id);
+        $id = $this->_getElementId('linkeditor_title');
+        $wrapperContent[] = new cHTMLLabel(i18n('Title'), $id);
         $title = conHtmlEntityDecode($this->getSetting('linkeditor_title'));
-        $wrapperContent[] = new cHTMLTextbox('linkeditor_title_' . $this->_id, $title, '', '', 'linkeditor_title_' . $this->_id);
-        $wrapperContent[] = new cHTMLCheckbox('linkeditor_newwindow_' . $this->_id, '', 'linkeditor_newwindow_' . $this->_id, ($this->getSetting('linkeditor_newwindow') === 'true'));
-        $wrapperContent[] = new cHTMLLabel(i18n('Open in a new window'), 'linkeditor_newwindow_' . $this->_id);
+        $wrapperContent[] = new cHTMLTextbox('linkeditor_title_' . $this->_id, $title, '', '', $id);
+
+        $id = $this->_getElementId('linkeditor_newwindow');
+        $wrapperContent[] = new cHTMLCheckbox('linkeditor_newwindow_' . $this->_id, '', $id, ($this->getSetting('linkeditor_newwindow') === 'true'));
+        $wrapperContent[] = new cHTMLLabel(i18n('Open in a new window'), $id);
 
         $wrapper->setContent($wrapperContent);
 
@@ -389,7 +390,8 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $wrapper = new cHTMLDiv();
         $wrapperContent = [];
 
-        $directoryList = new cHTMLDiv('', 'directoryList', 'directoryList' . '_' . $this->_id);
+        $id = $this->_getElementId('linkeditor_title');
+        $directoryList = new cHTMLDiv('', 'con_directory_list', 'con_directory_list' . '_' . $this->_id);
         $liRoot = new cHTMLListItem('root', 'last');
         $aUpload = new cHTMLLink('#');
         $aUpload->setClass('on');
@@ -407,7 +409,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $directoryList->setContent($conStrTree);
         $wrapperContent[] = $directoryList;
         $wrapperContent[] = new cHTMLDiv(
-            $this->generateArticleSelect(), 'directoryFile', 'directoryFile' . '_' . $this->_id
+            $this->generateArticleSelect(), 'con_directory_file', 'con_directory_file' . '_' . $this->_id
         );
 
         $wrapper->setContent($wrapperContent);
@@ -671,8 +673,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $newDirForm->setAttribute('name', 'newdir');
         $newDirForm->setAttribute('method', 'post');
         $newDirForm->setAttribute('action', cRegistry::getBackendUrl() . 'main.php');
-        $caption1Span = new cHTMLSpan();
-        $caption1Span->setID('caption1');
+        $caption1Span = new cHTMLSpan('', 'con_caption con_caption1');
         $newDirHead = new cHTMLDiv([
             '<b>' . i18n('Create a directory in') . '</b>',
             $caption1Span
@@ -716,8 +717,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $action = new cHTMLHiddenField('action', 'upl_upload');
         $appendparameters = new cHTMLHiddenField('appendparameters');
         $contenido = new cHTMLHiddenField('contenido', $_REQUEST['contenido']);
-        $caption2Span = new cHTMLSpan();
-        $caption2Span->setID('caption2');
+        $caption2Span = new cHTMLSpan('', 'con_caption con_caption2');
         $propertiesHead = new cHTMLDiv([
             '<b>' . i18n('Path') . '</b>',
             $caption2Span
@@ -740,7 +740,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $wrapperContent[] = new cHTMLImage(cRegistry::getBackendUrl() . 'images/ajax-loader.gif', 'loading');
 
         // directory navigation
-        $directoryList = new cHTMLDiv('', 'directoryList', 'directoryList_' . $this->_id);
+        $directoryList = new cHTMLDiv('', 'con_directory_list', 'con_directory_list_' . $this->_id);
         $liRoot = new cHTMLListItem('root', 'last');
         $aUpload = new cHTMLLink('#');
         $aUpload->setClass('on');
@@ -762,7 +762,7 @@ class cContentTypeLinkeditor extends cContentTypeAbstractTabbed
         $directoryList->setContent($conStrTree);
         $wrapperContent[] = $directoryList;
 
-        $wrapperContent[] = new cHTMLDiv($this->getUploadFileSelect('', true), 'directoryFile', 'directoryFile' . '_' . $this->_id);
+        $wrapperContent[] = new cHTMLDiv($this->getUploadFileSelect('', true), 'con_directory_file', 'con_directory_file' . '_' . $this->_id);
 
         $wrapper->setContent($wrapperContent);
 

--- a/contenido/classes/content_types/class.content.type.teaser.php
+++ b/contenido/classes/content_types/class.content.type.teaser.php
@@ -321,31 +321,35 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
                 $options['start'] = true;
             }
 
-            $artCollector = new cArticleCollector($options);
-            foreach ($artCollector as $article) {
-                $title = $this->_getArtContent(
-                    $article,
-                    $this->getSetting('teaser_source_head'),
-                    $this->getSetting('teaser_source_head_count')
-                );
-                $text = $this->_getArtContent(
-                    $article,
-                    $this->getSetting('teaser_source_text'),
-                    $this->getSetting('teaser_source_text_count')
-                );
-                $image = $this->_getArtContent(
-                    $article,
-                    $this->getSetting('teaser_source_image'),
-                    $this->getSetting('teaser_source_image_count')
-                );
+            try {
+                $artCollector = new cArticleCollector($options);
+                foreach ($artCollector as $article) {
+                    $title = $this->_getArtContent(
+                        $article,
+                        $this->getSetting('teaser_source_head'),
+                        $this->getSetting('teaser_source_head_count')
+                    );
+                    $text = $this->_getArtContent(
+                        $article,
+                        $this->getSetting('teaser_source_text'),
+                        $this->getSetting('teaser_source_text_count')
+                    );
+                    $image = $this->_getArtContent(
+                        $article,
+                        $this->getSetting('teaser_source_image'),
+                        $this->getSetting('teaser_source_image_count')
+                    );
 
-                if (trim($title) || trim($text) || trim($image)) {
-                    if ($returnAsArray == true) {
-                        $articles[] = $article;
-                    } else {
-                        $this->_fillTeaserTemplateEntry($article, $template);
+                    if (trim($title) || trim($text) || trim($image)) {
+                        if ($returnAsArray) {
+                            $articles[] = $article;
+                        } else {
+                            $this->_fillTeaserTemplateEntry($article, $template);
+                        }
                     }
                 }
+            } catch (Exception $e) {
+                cLogError($e->getMessage());
             }
         }
 
@@ -657,20 +661,18 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
         $templateTabs->set('s', 'PREFIX', $this->_prefix);
 
         // create code for general tab
-        $templateTabs->set('d', 'TAB_ID', 'general');
-        $templateTabs->set('d', 'TAB_CLASS', 'general');
+#        $templateTabs->set('d', 'TAB_ID', 'general');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_general_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabGeneral());
         $templateTabs->next();
 
         // create code for advanced tab
-        $templateTabs->set('d', 'TAB_ID', 'advanced');
-        $templateTabs->set('d', 'TAB_CLASS', 'advanced');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_advanced_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabAdvanced());
         $templateTabs->next();
 
         // create code for manual tab
-        $templateTabs->set('d', 'TAB_ID', 'manual');
-        $templateTabs->set('d', 'TAB_CLASS', 'manual');
+        $templateTabs->set('d', 'TAB_CLASS', 'con_tab_manual_content');
         $templateTabs->set('d', 'TAB_CONTENT', $this->_generateTabManual());
         $templateTabs->next();
 
@@ -681,6 +683,7 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
 
         // construct the top code of the template
         $templateTop = new cTemplate();
+        $templateTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $templateTop->set('s', 'ICON', 'images/isstart0.gif');
         $templateTop->set('s', 'ID', $this->_id);
         $templateTop->set('s', 'PREFIX', $this->_prefix);
@@ -692,9 +695,9 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
 
         // define the available tabs
         $tabMenu = [
-            'general' => i18n('Automatic'),
-            'advanced' => i18n('Manual'),
-            'manual' => i18n('Settings'),
+            'con_tab_general' => i18n('Automatic'),
+            'con_tab_advanced' => i18n('Manual'),
+            'con_tab_manual' => i18n('Settings'),
         ];
 
         // construct the bottom code of the template
@@ -768,30 +771,31 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
 
         // $wrapperContent[] = new cHTMLParagraph(i18n('General settings'),
         // 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n('Teaser title'), 'teaser_title_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Teaser title'), $this->_getElementId('teaser_title'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_title_' . $this->_id,
+            'teaser_title',
             conHtmlSpecialChars($this->getSetting('teaser_title')),
             '',
             '',
-            'teaser_title_' . $this->_id
+            $this->_getElementId('teaser_title')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Source category'), 'teaser_category_' . $this->_id);
-        $wrapperContent[] =
-            buildCategorySelect('teaser_category_' . $this->_id, $this->getSetting('teaser_category'), 0);
-        $wrapperContent[] = new cHTMLLabel(i18n('Number of articles'), 'teaser_count_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Source category'), $this->_getElementId('teaser_category'));
+        $wrapperContent[] = buildCategorySelect(
+            'teaser_category', $this->getSetting('teaser_category'), 0
+        );
+        $wrapperContent[] = new cHTMLLabel(i18n('Number of articles'), $this->_getElementId('teaser_count'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_count_' . $this->_id, cSecurity::toInteger($this->getSetting('teaser_count')), '', '', 'teaser_count_' . $this->_id
+            'teaser_count', cSecurity::toInteger($this->getSetting('teaser_count')), '', '', $this->_getElementId('teaser_count')
         );
 
-        $wrapperContent[] = new cHTMLLabel(i18n("Include start article"), 'teaser_start_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Include start article"), $this->_getElementId('teaser_start'));
         $wrapperContent[] = new cHTMLCheckbox(
-            'teaser_start_' . $this->_id, '', 'teaser_start_' . $this->_id, ($this->getSetting('teaser_start') == 'true')
+            'teaser_start', '', $this->_getElementId('teaser_start'), ($this->getSetting('teaser_start') == 'true')
         );
 
-        $wrapperContent[] = new cHTMLLabel(i18n("Teaser sort"), 'teaser_sort_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Teaser sort"), $this->_getElementId('teaser_sort'));
         $wrapperContent[] = $this->_generateSortSelect();
-        $wrapperContent[] = new cHTMLLabel(i18n("Sort order"), 'teaser_sort_order_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Sort order"), $this->_getElementId('teaser_sort_order'));
         $wrapperContent[] = $this->_generateSortOrderSelect();
 
         $wrapper->setContent($wrapperContent);
@@ -818,7 +822,7 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
      */
     private function _generateStyleSelect(): string
     {
-        $htmlSelect = new cHTMLSelectElement('teaser_style_' . $this->_id, '', 'teaser_style_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('teaser_style', '', $this->_getElementId('teaser_style'));
 
         // set please chose option element
         $htmlSelectOption = new cHTMLOptionElement(i18n("Please choose"), '', true);
@@ -869,12 +873,14 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
     private function _generateTypeSelect($selectName, $selected, $value): string
     {
         // make sure that the ID is at the end of the form field name
-        $inputName = str_replace('_' . $this->_id, '_count_' . $this->_id, $selectName);
+        $inputName = $selectName . '_count';
+        $inputId = $this->_getElementId($inputName);
         // generate textbox for content type id
-        $htmlInput = new cHTMLTextbox($inputName, $value, '', '', $inputName, false, '', '', 'teaser_type_count');
+        $htmlInput = new cHTMLTextbox($inputName, $value, '', '', $inputId, false, '', '', 'teaser_type_count');
 
         // generate content type select
-        $htmlSelect = new cHTMLSelectElement($selectName, '', $selectName);
+        $selectId = $this->_getElementId($selectName);
+        $htmlSelect = new cHTMLSelectElement($selectName, '', $selectId);
         $htmlSelect->setClass('teaser_type_select');
 
         $htmlSelectOption = new cHTMLOptionElement(i18n("Please choose"), '', true);
@@ -908,29 +914,30 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
         $wrapperContent = [];
 
         // $wrapperContent[] = new cHTMLParagraph(i18n('Manual teaser settings'), 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n('Manual teaser'), 'teaser_manual_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Manual teaser'), $this->_getElementId('teaser_manual'));
         $wrapperContent[] = new cHTMLCheckbox(
-            'teaser_manual_' . $this->_id,
+            'teaser_manual',
             '',
-            'teaser_manual_' . $this->_id,
+            $this->_getElementId('teaser_manual'),
             ($this->getSetting('teaser_manual') == 'true')
         );
 
         // $wrapperContent[] = new cHTMLParagraph(i18n('Add article'), 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n('Category'), 'teaser_cat_' . $this->_id);
-        $wrapperContent[] = buildCategorySelect('teaser_cat_' . $this->_id, 0, 0);
-        $wrapperContent[] = new cHTMLLabel(i18n('Article'), 'teaser_art_' . $this->_id);
-        $wrapperContent[] = buildArticleSelect('teaser_art_' . $this->_id, 0, 0);
+        $wrapperContent[] = new cHTMLLabel(i18n('Category'), $this->_getElementId('teaser_cat'));
+        $wrapperContent[] = buildCategorySelect('teaser_cat', 0, 0, '', $this->_getElementId('teaser_cat'));
 
-        $wrapperContent[] = new cHTMLLabel(i18n('Add'), 'add_art_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Article'), $this->_getElementId('teaser_art'));
+        $wrapperContent[] = buildArticleSelect('teaser_art', 0, 0, '', $this->_getElementId('teaser_art'));
+
+        $wrapperContent[] = new cHTMLLabel(i18n('Add'), $this->_getElementId('add_art'));
         $image = new cHTMLImage(cRegistry::getBackendUrl() . 'images/but_art_new.gif');
-        $image->setAttribute('id', 'add_art_' . $this->_id);
+        $image->setAttribute('id', $this->_getElementId('add_art'));
         $image->appendStyleDefinition('cursor', 'pointer');
         $wrapperContent[] = $image;
 
         $wrapperContent[] = new cHTMLParagraph(i18n('Included articles'), 'head_sub');
         $selectElement = new cHTMLSelectElement(
-            'teaser_manual_art_' . $this->_id, '', 'teaser_manual_art_' . $this->_id, false, '', '', 'manual'
+            'teaser_manual_art', '', $this->_getElementId('teaser_manual_art'), false, '', '', 'manual'
         );
         $selectElement->setAttribute('size', '4');
         $selectElement->setAttribute('multiple', 'multiple');
@@ -950,9 +957,9 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
         }
         $wrapperContent[] = $selectElement;
 
-        $wrapperContent[] = new cHTMLLabel(i18n("Delete"), 'del_art_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Delete"), $this->_getElementId('del_art'));
         $image = new cHTMLImage(cRegistry::getBackendUrl() . 'images/delete.gif');
-        $image->setAttribute('id', 'del_art_' . $this->_id);
+        $image->setAttribute('id', $this->_getElementId('del_art'));
         $image->appendStyleDefinition('cursor', 'pointer');
         $wrapperContent[] = $image;
 
@@ -969,7 +976,7 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
      */
     private function _generateSortSelect(): string
     {
-        $htmlSelect = new cHTMLSelectElement('teaser_sort_' . $this->_id, '', 'teaser_sort_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('teaser_sort', '', $this->_getElementId('teaser_sort'));
 
         // set please chose option element
         $htmlSelectOption = new cHTMLOptionElement(i18n("Please choose"), '', true);
@@ -1005,7 +1012,7 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
      */
     private function _generateSortOrderSelect(): string
     {
-        $htmlSelect = new cHTMLSelectElement('teaser_sort_order_' . $this->_id, '', 'teaser_sort_order_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('teaser_sort_order', '', $this->_getElementId('teaser_sort_order'));
 
         // set please chose option element
         $htmlSelectOption = new cHTMLOptionElement(i18n("Please choose"), '', true);
@@ -1032,7 +1039,7 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
      */
     private function _generateCropSelect(): string
     {
-        $htmlSelect = new cHTMLSelectElement('teaser_image_crop_' . $this->_id, '', 'teaser_image_crop_' . $this->_id);
+        $htmlSelect = new cHTMLSelectElement('teaser_image_crop', '', $this->_getElementId('teaser_image_crop'));
 
         // set please chose option element
         $htmlSelectOption = new cHTMLOptionElement(i18n("Please choose"), '', true);
@@ -1066,71 +1073,71 @@ class cContentTypeTeaser extends cContentTypeAbstractTabbed
         $wrapperContent = [];
 
         $wrapperContent[] = new cHTMLParagraph(i18n("Content visualisation"), 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n("Teaser visualisation"), 'teaser_style');
+        $wrapperContent[] = new cHTMLLabel(i18n("Teaser visualisation"), $this->_getElementId('teaser_style'));
         $wrapperContent[] = $this->_generateStyleSelect();
-        $wrapperContent[] = new cHTMLLabel(i18n("Teaser filter"), 'teaser_filter_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Teaser filter"), $this->_getElementId('teaser_filter'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_filter_' . $this->_id, $this->getSetting('teaser_filter'), '', '', 'teaser_filter_' . $this->_id
+            'teaser_filter', $this->getSetting('teaser_filter'), '', '', $this->_getElementId('teaser_filter')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Character length'), 'teaser_character_limit_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Character length'), $this->_getElementId('teaser_character_limit'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_character_limit_' . $this->_id,
+            'teaser_character_limit',
             $this->getSetting('teaser_character_limit'),
             '',
             '',
-            'teaser_character_limit_' . $this->_id
+            $this->_getElementId('teaser_character_limit')
         );
 
         $wrapperContent[] = new cHTMLParagraph(i18n("Pictures"), 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n('Image width'), 'teaser_image_width_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Image width'), $this->_getElementId('teaser_image_width'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_image_width_' . $this->_id,
+            'teaser_image_width',
             $this->getSetting('teaser_image_width'),
             '',
             '',
-            'teaser_image_width_' . $this->_id
+            $this->_getElementId('teaser_image_width')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Image height'), 'teaser_image_height_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Image height'), $this->_getElementId('teaser_image_height'));
         $wrapperContent[] = new cHTMLTextbox(
-            'teaser_image_height_' . $this->_id,
+            'teaser_image_height',
             $this->getSetting('teaser_image_height'),
             '',
             '',
-            'teaser_image_height_' . $this->_id
+            $this->_getElementId('teaser_image_height')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Image scale'), 'teaser_image_crop_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Image scale'), $this->_getElementId('teaser_image_crop'));
         $wrapperContent[] = $this->_generateCropSelect();
 
-        $wrapperContent[] = new cHTMLLabel(i18n("Use original image"), 'teaser_image_original_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Use original image"), $this->_getElementId('teaser_image_original'));
         $wrapperContent[] = new cHTMLCheckbox(
-            'teaser_image_original_' . $this->_id,
+            'teaser_image_original',
             '',
-            'teaser_image_original_' . $this->_id,
+            $this->_getElementId('teaser_image_original'),
             ($this->getSetting('teaser_image_original') == 'true')
         );
 
         $wrapperContent[] = new cHTMLParagraph(i18n("Content types"), 'head_sub');
-        $wrapperContent[] = new cHTMLLabel(i18n("Headline source"), 'teaser_source_head_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Headline source"), $this->_getElementId('teaser_source_head'));
         $wrapperContent[] = $this->_generateTypeSelect(
-            'teaser_source_head_' . $this->_id,
+            'teaser_source_head',
             $this->getSetting('teaser_source_head'),
             $this->getSetting('teaser_source_head_count')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n("Text source"), 'teaser_source_text_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n("Text source"), $this->_getElementId('teaser_source_text'));
         $wrapperContent[] = $this->_generateTypeSelect(
-            'teaser_source_text_' . $this->_id,
+            'teaser_source_text',
             $this->getSetting('teaser_source_text'),
             $this->getSetting('teaser_source_text_count')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Image source'), 'teaser_source_image_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Image source'), $this->_getElementId('teaser_source_image'));
         $wrapperContent[] = $this->_generateTypeSelect(
-            'teaser_source_image_' . $this->_id,
+            'teaser_source_image',
             $this->getSetting('teaser_source_image'),
             $this->getSetting('teaser_source_image_count')
         );
-        $wrapperContent[] = new cHTMLLabel(i18n('Date source'), 'teaser_source_date_' . $this->_id);
+        $wrapperContent[] = new cHTMLLabel(i18n('Date source'), $this->_getElementId('teaser_source_date'));
         $wrapperContent[] = $this->_generateTypeSelect(
-            'teaser_source_date_' . $this->_id,
+            'teaser_source_date',
             $this->getSetting('teaser_source_date'),
             $this->getSetting('teaser_source_date_count')
         );

--- a/contenido/classes/html/class.html.label.php
+++ b/contenido/classes/html/class.html.label.php
@@ -53,7 +53,9 @@ class cHTMLLabel extends cHTMLContentElement
     {
         parent::__construct('', $class, $id);
         $this->_tag = 'label';
-        $this->updateAttribute('for', $for);
+        if (!empty($for)) {
+            $this->updateAttribute('for', $for);
+        }
         $this->text = $text;
     }
 

--- a/contenido/includes/functions.general.php
+++ b/contenido/includes/functions.general.php
@@ -1123,29 +1123,31 @@ function cSetArtSpecDefault(int $idArtSpec): bool
 /**
  * Build a Article select Box
  *
- * @param string $sName
- *         Name of the SelectBox
- * @param string $iIdCat
- *         Category id
- * @param string $sValue
- *         Value of the SelectBox
- *
- * @return string
- *         HTML
+ * @param string $name Name of the SelectBox
+ * @param int|string $idCat Category id
+ * @param string $value Value of the SelectBox
+ * @param string $idAttr Id attribute value
+ * @param string $cssClass Optional css class for select
+ * @return string HTML
  *
  * @throws cDbException
  * @throws cException
  */
-function buildArticleSelect($sName, $iIdCat, $sValue)
+function buildArticleSelect(
+    $name, $idCat, $value, string $cssClass = '', string $idAttr = ''
+): string
 {
     static $cache;
 
     $lang = cRegistry::getLanguageId();
+    if (empty($idAttr)) {
+        $idAttr = $name;
+    }
 
     if (!isset($cache)) {
         $cache = [];
     }
-    $cacheKey = implode('/', [$lang, $sName, $iIdCat]);
+    $cacheKey = implode('/', [$lang, $name, $idCat]);
 
     if (isset($cache[$cacheKey])) {
         // Get data from cache
@@ -1161,7 +1163,7 @@ function buildArticleSelect($sName, $iIdCat, $sValue)
                WHERE ca.idcat = %d AND al.idlang = %d AND al.idart = a.idart AND al.idart = ca.idart
                ORDER BY al.title';
 
-        $db->query($sql, $cfg['tab']['art'], $cfg['tab']['art_lang'], $cfg['tab']['cat_art'], $iIdCat, $lang);
+        $db->query($sql, $cfg['tab']['art'], $cfg['tab']['art_lang'], $cfg['tab']['cat_art'], $idCat, $lang);
         while ($db->nextRecord()) {
             $data[] = [
                 'idart' => $db->f('idart'),
@@ -1173,10 +1175,13 @@ function buildArticleSelect($sName, $iIdCat, $sValue)
     }
 
     // Build the select
-    $selectElem = new cHTMLSelectElement($sName, "", $sName);
+    $selectElem = new cHTMLSelectElement($name, "", $idAttr);
+    if (!empty($cssClass)) {
+        $selectElem->setClass($cssClass);
+    }
     $selectElem->appendOptionElement(new cHTMLOptionElement(i18n("Please choose"), ""));
     foreach ($data as $entry) {
-        $selected = ($sValue == $entry['idart']);
+        $selected = ($value == $entry['idart']);
         $selectElem->appendOptionElement(new cHTMLOptionElement($entry['title'], $entry['idart'], $selected));
     }
 
@@ -1187,24 +1192,30 @@ function buildArticleSelect($sName, $iIdCat, $sValue)
  * Build a Category / Article select Box
  *
  * @staticvar array $cache Cache for DB results
- * @param string $sName Name of the SelectBox
- * @param string $sValue Value of the SelectBox
- * @param int $sLevel Value of the highest level that should be shown
- * @param string $sClass Optional css class for select
+ * @param string $name Name of the SelectBox
+ * @param string $value Value of the SelectBox
+ * @param int $level Value of the highest level that should be shown
+ * @param string $cssClass Optional css class for select
+ * @param string $idAttr Id attribute value
  * @return string HTML select generated
  */
-function buildCategorySelect($sName, $sValue, $sLevel = 0, $sClass = '')
+function buildCategorySelect(
+    $name, $value, $level = 0, string $cssClass = '', string $idAttr = ''
+): string
 {
     static $cache;
 
     $client = cRegistry::getClientId();
     $lang = cRegistry::getLanguageId();
+    if (empty($idAttr)) {
+        $idAttr = $name;
+    }
 
     if (!isset($cache)) {
         $cache = [];
     }
 
-    $cacheKey = implode('/', [$client, $lang, $sLevel]);
+    $cacheKey = implode('/', [$client, $lang, $level]);
 
     if (isset($cache[$cacheKey])) {
         // Get data from cache
@@ -1216,7 +1227,7 @@ function buildCategorySelect($sName, $sValue, $sLevel = 0, $sClass = '')
         $db = cRegistry::getDb();
         $cfg = cRegistry::getConfig();
 
-        $addString = ($sLevel > 0) ? "AND c.level < " . (int)$sLevel : '';
+        $addString = ($level > 0) ? "AND c.level < " . (int) $level : '';
 
         $sql = "SELECT a.idcat AS idcat, b.name AS name, c.level FROM `:tab_cat` AS a, `:tab_cat_lang` AS b,
            `:tab_cat_tree` AS c WHERE a.idclient = :client AND b.idlang = :lang AND b.idcat = a.idcat 
@@ -1254,14 +1265,16 @@ function buildCategorySelect($sName, $sValue, $sLevel = 0, $sClass = '')
     }
 
     // Build the select
-    $selectElem = new cHTMLSelectElement($sName, '', $sName);
-    $selectElem->setClass($sClass);
+    $selectElem = new cHTMLSelectElement($name, '', $idAttr);
+    if (!empty($cssClass)) {
+        $selectElem->setClass($cssClass);
+    }
     $selectElem->appendOptionElement(new cHTMLOptionElement(i18n("Please choose"), ''));
 
-    foreach ($data as $tmpidcat => $props) {
+    foreach ($data as $tmpIdCat => $props) {
         $spaces = cHTMLOptionElement::indent(cSecurity::toInteger($props['level']));
-        $selected = ($sValue == $tmpidcat);
-        $selectElem->appendOptionElement(new cHTMLOptionElement($spaces . '>' . $props['name'], $tmpidcat, $selected));
+        $selected = ($value == $tmpIdCat);
+        $selectElem->appendOptionElement(new cHTMLOptionElement($spaces . '>' . $props['name'], $tmpIdCat, $selected));
     }
 
     return $selectElem->toHtml();

--- a/contenido/plugins/form_assistant/classes/class.content.type.pifa_form.php
+++ b/contenido/plugins/form_assistant/classes/class.content.type.pifa_form.php
@@ -96,6 +96,7 @@ class cContentTypePifaForm extends cContentTypeAbstractTabbed
     {
         // build top code
         $tplTop = new cTemplate();
+        $tplTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $tplTop->set('s', 'ICON', 'plugins/form_assistant/images/icon_form.png');
         $tplTop->set('s', 'ID', $this->_id);
         $tplTop->set('s', 'PREFIX', $this->_prefix);
@@ -104,7 +105,7 @@ class cContentTypePifaForm extends cContentTypeAbstractTabbed
 
         // available tabs
         $tabMenu = [
-            'base' => Pifa::i18n('form')
+            'con_tab_base' => Pifa::i18n('form')
         ];
 
         // build tab code

--- a/contenido/plugins/form_assistant/plugin.xml
+++ b/contenido/plugins/form_assistant/plugin.xml
@@ -13,7 +13,7 @@
         <copyright>four for business AG</copyright>
         <mail>marcus.gnass@4fb.de</mail>
         <website>https://www.4fb.de</website>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
     </general>
     <requirements php="7.0">
         <contenido minversion="4.10.2-dev"/>

--- a/contenido/plugins/user_forum/classes/class.content.type.user_forum.php
+++ b/contenido/plugins/user_forum/classes/class.content.type.user_forum.php
@@ -73,6 +73,7 @@ class cContentTypeUserForum extends cContentTypeAbstractTabbed
 
         // build top code
         $tplTop = new cTemplate();
+        $tplTop->set('s', 'CONTENT_TYPE_ID', $this->_contentTypeId);
         $tplTop->set('s', 'ICON', 'plugins/user_forum/images/con_button.gif');
         $tplTop->set('s', 'ID', $this->_id);
         $tplTop->set('s', 'PREFIX', $this->_prefix);
@@ -80,7 +81,7 @@ class cContentTypeUserForum extends cContentTypeAbstractTabbed
         $codeTop = $tplTop->generate($this->_cfg['path']['contenido'] . 'templates/standard/template.cms_abstract_tabbed_edit_top.html', true);
 
         // available tabs
-        // $tabMenu = array('base' => Pifa::i18n('form'));
+        // $tabMenu = array('con_tab_base' => Pifa::i18n('form'));
 
         // build tab code
         $tplPanel = new cTemplate();

--- a/contenido/plugins/user_forum/plugin.xml
+++ b/contenido/plugins/user_forum/plugin.xml
@@ -9,7 +9,7 @@
         <copyright>four for business AG</copyright>
         <mail>claus.schunk@4fb.de</mail>
         <website>https://www.4fb.de</website>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
     </general>
     <requirements php="7.0">
         <contenido minversion="4.10.2-dev"/>

--- a/contenido/scripts/base64.js
+++ b/contenido/scripts/base64.js
@@ -1,0 +1,169 @@
+/**
+ * Project:
+ * CONTENIDO Content Management System
+ *
+ * Description:
+ * Base64 encode / decode.
+ * Functionality is taken over from contenido/scripts/content_types/cmsDate.js.
+ * 
+ * Source:
+ * http://www.webtoolkit.info/
+ *
+ * @module     base64
+ * @requires   jQuery
+ * @author     Simon Sprankel
+ * @author     Murat Purc <murat@purc.de>
+ * @copyright  four for business AG <www.4fb.de>
+ * @license    https://www.contenido.org/license/LIZENZ.txt
+ * @link       https://www.4fb.de
+ * @link       https://www.contenido.org
+ * @requires   jQuery JavaScript Framework
+ */
+
+(function(Con, $) {
+
+    // 'use strict';
+
+    var NAME = 'base64';
+
+    var KEY_STR = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+
+        // private method for UTF-8 encoding
+    function _utf8_encode(string) {
+        string = string.replace(/\r\n/g,"\n");
+        var utftext = "";
+
+        for (var n = 0; n < string.length; n++) {
+            var c = string.charCodeAt(n);
+
+            if (c < 128) {
+                utftext += String.fromCharCode(c);
+            } else if ((c > 127) && (c < 2048)) {
+                utftext += String.fromCharCode((c >> 6) | 192);
+                utftext += String.fromCharCode((c & 63) | 128);
+            } else {
+                utftext += String.fromCharCode((c >> 12) | 224);
+                utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+                utftext += String.fromCharCode((c & 63) | 128);
+            }
+        }
+
+        return utftext;
+    }
+
+    // private method for UTF-8 decoding
+    function _utf8_decode(utftext) {
+        var string = "";
+        var i = 0;
+        var c = 0;
+        var c2 = 0;
+        var c3 = 0;
+
+        while (i < utftext.length) {
+            c = utftext.charCodeAt(i);
+
+            if (c < 128) {
+                string += String.fromCharCode(c);
+                i++;
+            } else if ((c > 191) && (c < 224)) {
+                c2 = utftext.charCodeAt(i+1);
+                string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+                i += 2;
+            } else {
+                c2 = utftext.charCodeAt(i+1);
+                c3 = utftext.charCodeAt(i+2);
+                string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
+                i += 3;
+            }
+        }
+
+        return string;
+    }
+
+
+    /**
+     * Base64 class
+     * @class Base64
+     * @static
+     */
+    var Base64 = {
+
+        /**
+         * Encode input string.
+         *
+         * @param {string} input
+         * @return {string}
+         */
+        encode: function(input) {
+            var output = "";
+            var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+            var i = 0;
+
+            input = _utf8_encode(input);
+
+            while (i < input.length) {
+                chr1 = input.charCodeAt(i++);
+                chr2 = input.charCodeAt(i++);
+                chr3 = input.charCodeAt(i++);
+
+                enc1 = chr1 >> 2;
+                enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+                enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+                enc4 = chr3 & 63;
+
+                if (isNaN(chr2)) {
+                    enc3 = enc4 = 64;
+                } else if (isNaN(chr3)) {
+                    enc4 = 64;
+                }
+
+                output = output 
+                    + KEY_STR.charAt(enc1) + KEY_STR.charAt(enc2)
+                    + KEY_STR.charAt(enc3) + KEY_STR.charAt(enc4);
+            }
+
+            return output;
+        },
+
+        /**
+         * Decode input string.
+         *
+         * @param {string} input
+         * @return {string}
+         */
+        decode: function(input) {
+            var output = "";
+            var chr1, chr2, chr3;
+            var enc1, enc2, enc3, enc4;
+            var i = 0;
+
+            input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+
+            while (i < input.length) {
+                enc1 = KEY_STR.indexOf(input.charAt(i++));
+                enc2 = KEY_STR.indexOf(input.charAt(i++));
+                enc3 = KEY_STR.indexOf(input.charAt(i++));
+                enc4 = KEY_STR.indexOf(input.charAt(i++));
+
+                chr1 = (enc1 << 2) | (enc2 >> 4);
+                chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+                chr3 = ((enc3 & 3) << 6) | enc4;
+
+                output = output + String.fromCharCode(chr1);
+
+                if (enc3 !== 64) {
+                    output = output + String.fromCharCode(chr2);
+                }
+                if (enc4 !== 64) {
+                    output = output + String.fromCharCode(chr3);
+                }
+            }
+
+            return _utf8_decode(output);
+        }
+    };
+
+    Con.Base64 = Base64;
+
+})(Con, Con.$);

--- a/contenido/scripts/content_types/cmsAbstractTabbed.js
+++ b/contenido/scripts/content_types/cmsAbstractTabbed.js
@@ -111,7 +111,7 @@
         /**
          * Reference to tabbed frame node
          * @property $frame
-         * @type {HTMLElement[]}
+         * @type {jQuery}
          */
         this.$frame = $(this.frameId);
     }
@@ -165,26 +165,25 @@
      * @param {String} value The value of the form field which should be added.
      */
     cContentTypeAbstractTabbed.prototype.appendFormField = function(name, value) {
+        var $formEditContent = $('form[name="editcontent"]');
     	// CON-2142
         // jQuery transforms special strings like &auml; to ä during append
         // if a hidden input field with the given name already exists, just set the value
-        if ($('form[name="editcontent"] input[type="hidden"][name="' + name + '"]').length > 0) {
-            $('form[name="editcontent"] input[type="hidden"][name="' + name + '"]').val(value);
+        if ($formEditContent.find('input[type="hidden"][name="' + name + '"]').length > 0) {
+            $formEditContent.find('input[type="hidden"][name="' + name + '"]').val(value);
         } else {
             // otherwise append a new field to the form
-
-            $('form[name="editcontent"]').append('<input type="hidden" name="' + name + '"/>');
-            $('form[name="editcontent"] input:last-child').attr('value', value);
+            $formEditContent.append('<input type="hidden" name="' + name + '"/>');
+            $formEditContent.find('input:last-child').attr('value', value);
         }
     };
 
     /**
-     * Adds event which fades in the edit form when editbutton is clicked.
+     * Adds event which fades in the edit form when edit button is clicked.
      * @method addFrameShowEvent
      */
     cContentTypeAbstractTabbed.prototype.addFrameShowEvent = function() {
         var self = this;
-        $(this.imageId).css('cursor', 'pointer');
         $(this.imageId).click(function() {
             var top = $(document).scrollTop()+($(window).height()/2);
             $('body').addClass('cms_has_overlay');
@@ -204,18 +203,28 @@
      */
     cContentTypeAbstractTabbed.prototype.addTabbingEvents = function() {
         var self = this,
-            $items = this.$frame.find('.menu li');
+            $items = this.$frame.find('.con_tab_menu li');
+
         // add layer click events
         $items.click(function() {
+            var $tab = $(this),
+                className = $tab.data('tabContent');
+
+            if ($tab.hasClass('active')) {
+                // Tab is already active
+                return;
+            }
+
             $items.removeClass('active');
             // hide all tabs but the active one
-            self.$frame.find('.tabs > div:not(#' + $(this).attr('class') + ')').hide();
+            self.$frame.find('.con_tab_content > div:not(.' + className + ')').hide();
             // add smooth animation
-            self.$frame.find('#' + $(this).attr('class')).fadeIn('normal');
-            $(this).addClass('active');
+            self.$frame.find('.con_tab_content > .' + className).fadeIn('normal');
+            $tab.addClass('active');
         });
+
         // trigger the click event on the first tab so that the others are hidden etc.
-        self.$frame.find('.menu li:first').click();
+        self.$frame.find('.con_tab_menu li:first').click();
     };
 
     /**
@@ -229,8 +238,8 @@
         $elem.click(function() {
             for (var i = 0; i < self.fields.length; i++) {
                 var value = '',
-                    name = self.fields[i] + '_' + self.id,
-                    $item = self.$frame.find('#' + name);
+                    name = self.fields[i],
+                    $item = self.$frame.find('[name="' + name + '"]');
                 if ($item.is('input[type="checkbox"]')) {
                     // special behaviour for checkboxes
                     value = $item.prop('checked');
@@ -251,7 +260,7 @@
                     // default value for select boxes and text boxes
                     value = $item.val();
                 }
-                name = name.replace('_' + self.id, '');
+                //name = name.replace('_' + self.id, '');
                 self.appendFormField(name, value);
             }
             self.appendFormField(self.prefix + '_action', 'store');
@@ -282,6 +291,41 @@
         });
     };
 
+    /**
+     * Returns the content type setting element by its name.
+     * @method getSettingElement
+     * @param {String} name
+     * @return {jQuery}
+     */
+    cContentTypeAbstractTabbed.prototype.getSettingElement = function(name) {
+        return this.$frame.find('[name="' + name + '"]');
+    };
+
+    /**
+     * Returns an element class name within current tabbed frame, prefixed by CMS Type
+     * identifier (e.g. `cms_image_1_`).
+     * @method getElementCssClass
+     * @param {String} name
+     * @return {String} Element class name, e.g. 'cms_image_1_{name}'
+     */
+    cContentTypeAbstractTabbed.prototype.getElementCssClass = function(name) {
+        return this.getElementId(name);
+    };
+
+    /**
+     * Returns an element identifier name within current tabbed frame, prefixed by CMS Type
+     * identifier (e.g. `cms_image_1_`).
+     * @method getElementCssClass
+     * @param {String} name
+     * @return {String} Element identifier, e.g. 'cms_image_1_{name}'
+     */
+    cContentTypeAbstractTabbed.prototype.getElementId = function(name) {
+        if (this.imageId.length) {
+            return this.imageId.substring(1) + '_' + name;
+        } else {
+            return '';
+        }
+    };
 
     Con.cContentTypeAbstractTabbed = cContentTypeAbstractTabbed;
 

--- a/contenido/scripts/content_types/cmsDate.js
+++ b/contenido/scripts/content_types/cmsDate.js
@@ -4,6 +4,7 @@
  * This file contains the cContentTypeDate JS class.
  *
  * @module     content-type
+ * @requires   jQuery, Con, Con.Base64
  * @submodule  content-type-cms-date
  * @package    Core
  * @subpackage Content Type
@@ -33,6 +34,13 @@
      * @property {String} belang The backend language (e.g. de_DE).
      */
     function cContentTypeDate(frameId, prefix, id, idArtLang, pathBackend, lang, settings, belang) {
+
+        /**
+         * Reference to cms type node
+         * @property $frame
+         * @type {jQuery}
+         */
+        this.$frame = $(frameId);
 
         /**
          * ID of the frame in which all settings are made.
@@ -95,8 +103,21 @@
          * @property $element
          * @type {HTMLElement[]}
          */
-        this.$element = $('#date_timestamp_' + this.id);
+        this.$element = this.$frame.find('.con_element.date_timestamp');
 
+        /**
+         * Reference to the current content type element
+         * @property $dateFormatSelect
+         * @type {HTMLElement[]}
+         */
+        this.$dateFormatSelect = this.$frame.find('.con_select.date_format_select');
+
+        /**
+         * Reference to the save settings button
+         * @property $saveSettings
+         * @type {HTMLElement[]}
+         */
+        this.$saveSettings = this.$frame.find('.save_settings');
     }
 
     /**
@@ -200,14 +221,13 @@
      * @method addSaveEvent
      */
     cContentTypeDate.prototype.addSaveEvent = function() {
-        var self = this,
-            $elem = $(this.frameId).find(' .save_settings');
-        $elem.css('cursor', 'pointer');
-        $elem.click(function() {
+        var self = this;
+        this.$saveSettings.css('cursor', 'pointer');
+        this.$saveSettings.click(function() {
             var date = self.$element.datetimepicker('getDate') || self.$element.datepicker('getDate') || self.$element.timepicker('getDate');
             var timestamp = Math.floor(date.getTime() / 1000);
-            var format = $(self.frameId + ' #date_format_select_' + self.id).val();
-            format = Base64.encode(format);
+            var format = self.$dateFormatSelect.val();
+            format = Con.Base64.encode(format);
             self.appendFormField(self.prefix + '_timestamp', timestamp);
             self.appendFormField(self.prefix + '_format', format);
             self.appendFormField(self.prefix + '_action', 'store');
@@ -219,7 +239,7 @@
     /**
      * Adds the given name/value pair as a hidden field to the editform so that it
      * is submitted to CONTENIDO. If a hidden field with the given name already
-     * exists, the value is overriden.
+     * exists, the value is overridden.
      *
      * @method appendFormField
      * @param {String} name The name of the form field which should be added.
@@ -240,143 +260,3 @@
     Con.cContentTypeDate = cContentTypeDate;
 
 })(Con, Con.$);
-
-
-/**
-*
-*  Base64 encode / decode
-*  http://www.webtoolkit.info/
-*
-**/
-
-var Base64 = {
-
-    // private property
-    _keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-
-    // public method for encoding
-    encode: function(input) {
-        var output = "";
-        var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-        var i = 0;
-
-        input = Base64._utf8_encode(input);
-
-        while (i < input.length) {
-
-            chr1 = input.charCodeAt(i++);
-            chr2 = input.charCodeAt(i++);
-            chr3 = input.charCodeAt(i++);
-
-            enc1 = chr1 >> 2;
-            enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-            enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-            enc4 = chr3 & 63;
-
-            if (isNaN(chr2)) {
-                enc3 = enc4 = 64;
-            } else if (isNaN(chr3)) {
-                enc4 = 64;
-            }
-
-            output = output +
-            this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
-            this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
-
-        }
-
-        return output;
-    },
-
-    // public method for decoding
-    decode: function(input) {
-        var output = "";
-        var chr1, chr2, chr3;
-        var enc1, enc2, enc3, enc4;
-        var i = 0;
-
-        input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-
-        while (i < input.length) {
-
-            enc1 = this._keyStr.indexOf(input.charAt(i++));
-            enc2 = this._keyStr.indexOf(input.charAt(i++));
-            enc3 = this._keyStr.indexOf(input.charAt(i++));
-            enc4 = this._keyStr.indexOf(input.charAt(i++));
-
-            chr1 = (enc1 << 2) | (enc2 >> 4);
-            chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-            chr3 = ((enc3 & 3) << 6) | enc4;
-
-            output = output + String.fromCharCode(chr1);
-
-            if (enc3 != 64) {
-                output = output + String.fromCharCode(chr2);
-            }
-            if (enc4 != 64) {
-                output = output + String.fromCharCode(chr3);
-            }
-
-        }
-
-        output = Base64._utf8_decode(output);
-
-        return output;
-
-    },
-
-    // private method for UTF-8 encoding
-    _utf8_encode: function(string) {
-        string = string.replace(/\r\n/g,"\n");
-        var utftext = "";
-
-        for (var n = 0; n < string.length; n++) {
-
-            var c = string.charCodeAt(n);
-
-            if (c < 128) {
-                utftext += String.fromCharCode(c);
-            } else if ((c > 127) && (c < 2048)) {
-                utftext += String.fromCharCode((c >> 6) | 192);
-                utftext += String.fromCharCode((c & 63) | 128);
-            } else {
-                utftext += String.fromCharCode((c >> 12) | 224);
-                utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-                utftext += String.fromCharCode((c & 63) | 128);
-            }
-
-        }
-
-        return utftext;
-    },
-
-    // private method for UTF-8 decoding
-    _utf8_decode: function(utftext) {
-        var string = "";
-        var i = 0;
-        var c = c1 = c2 = 0;
-
-        while (i < utftext.length) {
-
-            c = utftext.charCodeAt(i);
-
-            if (c < 128) {
-                string += String.fromCharCode(c);
-                i++;
-            } else if ((c > 191) && (c < 224)) {
-                c2 = utftext.charCodeAt(i+1);
-                string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-                i += 2;
-            } else {
-                c2 = utftext.charCodeAt(i+1);
-                c3 = utftext.charCodeAt(i+2);
-                string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-                i += 3;
-            }
-
-        }
-
-        return string;
-    }
-
-};

--- a/contenido/scripts/content_types/cmsFilelist.js
+++ b/contenido/scripts/content_types/cmsFilelist.js
@@ -43,20 +43,20 @@
         Con.cContentTypeAbstractTabbed.apply(this, arguments);
 
         // Define some jQuery selectors here for later usage
-        this.SELECTOR_FILELIST_MANUAL_FILES = $(this.frameId + ' #filelist_manual_files_' + this.id);
-        this.SELECTOR_FILELIST_FILENAME = this.frameId + ' #filelist_filename_' + this.id;
-        this.SELECTOR_CHK_FILELIST_MANUAL = this.frameId + ' #filelist_manual_' + this.id;
-        this.SELECTOR_MANUAL_FILELIST_SETTING = this.frameId + ' #manual_filelist_setting';
-        this.SELECTOR_METADATALIST = this.frameId + ' #metaDataList';
-        this.SELECTOR_FILELIST_INCL_METADATA = this.frameId + ' #filelist_incl_metadata_' + this.id;
-        this.SELECTOR_FILELIST_ALL_EXTENSIONS = this.frameId + ' #filelist_all_extensions';
-        this.SELECTOR_FILELIST_EXTENSIONS = this.frameId + ' #filelist_extensions_' + this.id;
-        this.SELECTOR_FILELIST_IGNORE_EXTENSIONS = this.frameId + ' #filelist_ignore_extensions_' + this.id;
+        this.SELECTOR_FILELIST_MANUAL_FILES = $(this.frameId + ' .filelist_manual_files');
+        this.SELECTOR_FILELIST_FILENAME = this.frameId + ' .con_tab_manual_content .filelist_filename';
+        this.SELECTOR_CHK_FILELIST_MANUAL = this.frameId + ' .filelist_manual';
+        this.SELECTOR_MANUAL_FILELIST_SETTING = this.frameId + ' .filelist_manual_filelist_setting';
+        this.SELECTOR_METADATALIST = this.frameId + ' .filelist_meta_data_list';
+        this.SELECTOR_FILELIST_INCL_METADATA = this.frameId + ' .filelist_incl_metadata';
+        this.SELECTOR_FILELIST_ALL_EXTENSIONS = this.frameId + ' .filelist_all_extensions';
+        this.SELECTOR_FILELIST_EXTENSIONS = this.frameId + ' .filelist_extensions';
+        this.SELECTOR_FILELIST_IGNORE_EXTENSIONS = this.frameId + ' .filelist_ignore_extensions';
         this.SELECTOR_SAVE_SETTINGS = this.frameId + ' .save_settings';
-        this.SELECTOR_DIRLIST = this.frameId + ' .directories #directoryList_' + this.id + ' li li div em a';
-        this.SELECTOR_DIRLIST_LINK = this.frameId + ' .directories #directoryList_' + this.id + ' li li div a';
-        this.SELECTOR_DIRLIST_ACTIVE = this.frameId + ' .directories #directoryList_' + this.id + ' div[class="active"]';
-        this.SELECTOR_DIRLIST_MANUAL = this.frameId + ' #manual #directoryList_' + this.id + '_manual li li div';
+        this.SELECTOR_DIRLIST = this.frameId + ' .con_tab_directories_content .con_directory_list li li div em a';
+        this.SELECTOR_DIRLIST_LINK = this.frameId + ' .con_tab_directories_content .con_directory_list li li div a';
+        this.SELECTOR_DIRLIST_ACTIVE = this.frameId + ' .con_tab_directories_content .con_directory_list div[class="active"]';
+        this.SELECTOR_DIRLIST_MANUAL = this.frameId + ' .con_tab_manual_content .con_directory_list li li div';
     }
 
     //inherit from cContentTypeAbstractTabbed
@@ -97,7 +97,7 @@
      */
     cContentTypeFilelist.prototype.addManualFileListEvent = function() {
         var self = this;
-        $(self.frameId + ' #add_file').css('cursor', 'pointer').click(function() {
+        $(self.frameId + ' .filelist_add_file').css('cursor', 'pointer').click(function() {
             self.addManualFileListEntry();
         });
     };
@@ -276,7 +276,7 @@
 						return false;
 					}
 
-                    $(self.frameId + ' #manual #filelist_filename_' + self.id).replaceWith(msg);
+                    $(self.SELECTOR_FILELIST_FILENAME).replaceWith(msg);
                 }
             });
 

--- a/contenido/scripts/content_types/cmsImgeditor.js
+++ b/contenido/scripts/content_types/cmsImgeditor.js
@@ -84,7 +84,7 @@
         this.addSelectAction();
         this.showFolderPath();
         this.createMKDir();
-        this.showUrlforMeta();
+        this.showUrlForMeta();
     };
 
     /**
@@ -98,7 +98,10 @@
         Con.cContentTypeAbstractTabbed.prototype.loadExternalFiles.call(this);
 
         Con.Loader.get(
-            [this.pathBackend + 'styles/content_types/cms_imgeditor.css', this.pathBackend + 'scripts/jquery/ajaxupload.js'],
+            [
+                this.pathBackend + 'styles/content_types/cms_imgeditor.css',
+                this.pathBackend + 'scripts/jquery/ajaxupload.js'
+            ],
             cContentTypeImgeditor.prototype.initUpload,
             this
         );
@@ -125,7 +128,7 @@
         // call the function of the parent so that the standard tab functionality works
         Con.cContentTypeAbstractTabbed.prototype.addTabbingEvents.call(self);
 
-        $(self.frameId + ' .menu li').click(function() {
+        this.$frame.find('.con_tab_menu li').click(function() {
             // refresh dirs list
             if (!self.refreshed) {
                 var folderName = self.getSelectedFolder();
@@ -135,8 +138,8 @@
             }
 
             // if the upload tab is shown, show the directories tab, too
-            if ($(this).hasClass('upload')) {
-                $(self.frameId + ' .tabs #directories').show();
+            if ($(this).hasClass('con_tab_upload')) {
+                self.$frame.find('.con_tab_content > .con_tab_directories_content').show();
                 self.showFolderPath();
             }
         });
@@ -149,10 +152,10 @@
         var self = this;
         var id = self.id;
 
-        var dlist = $(self.frameId + ' #directoryList_' + id + ' em a');
+        var dlist = self.$frame.find('.con_directory_list em a');
         var divContainer = dlist.closest('.con_str_tree');
 
-        $('#cms_imgeditor_' + id).on('click', function(e) {
+        $(this.imageId).on('click', function(e) {
             var folderName = self.getSelectedFolder();
             var dirname = self.getSelectedDir();
             self.updateDirList(dirname, folderName);
@@ -169,27 +172,25 @@
     cContentTypeImgeditor.prototype.addNaviActions = function() {
         var self = this;
 
-        $(self.frameId + ' ul.menu li.upload').click(function() {
-            if (self.scriptLoaded == 1) {
+        self.$frame.find('ul.con_tab_menu li.upload').click(function() {
+            if (self.scriptLoaded === 1) {
                 self.imageFileUpload();
             }
         });
 
         // init directories lists
-        $(self.frameId + ' #directoryList_' + self.id + ' a[class="on"]').parent('div').unbind('click');
-        $(self.frameId + ' #directoryList_' + self.id + ' a[class="on"]').parent('div').click(function() {
+        self.$frame.find('.con_directory_list a[class="on"]').parent('div').unbind('click');
+        self.$frame.find('.con_directory_list a[class="on"]').parent('div').click(function() {
             // update the "active" class
-            $.each($(self.frameId + ' div'), function() {
-                $(this).removeClass('active');
-            });
+            self.$frame.find('.con_directory_list div').removeClass('active');
             $(this).addClass('active');
             self.showActiveFilename();
             self.showFolderPath();
             return false;
         });
         // add possibility to expand and close directories
-        $(self.frameId + ' #directoryList_' + self.id + ' em a').unbind('click');
-        $(self.frameId + ' #directoryList_' + self.id + ' em a').click(function(e) {
+        self.$frame.find('.con_directory_list em a').unbind('click');
+        self.$frame.find('.con_directory_list em a').click(function(e) {
         	e.preventDefault();
             var divContainer = $(this).parent().parent();
             var dirname = $(this).parent('em').parent().find('a[class="on"]').attr('title');
@@ -229,15 +230,15 @@
         var self = this;
         // if there are no directories, set the active class for the root upload folder
         var directories = [];
-        $(self.frameId + ' div[class="active"] a[class="on"]').each(function() {
+        self.$frame.find('div[class="active"] a[class="on"]').each(function() {
             directories.push($(this).attr('title'));
         });
         if (directories.length < 1) {
-            $(self.frameId + ' li.root>div').addClass('active');
+            self.$frame.find('li.root>div').addClass('active');
         }
 
         // get the selected directory and save it
-        self.selectedPath = $(self.frameId + ' div[class="active"] a[class="on"]').attr('title');
+        self.selectedPath = self.$frame.find('div[class="active"] a[class="on"]').attr('title');
         var selectedPath = self.selectedPath;
         if (selectedPath !== '' && selectedPath !== 'upload') {
             selectedPath += '/';
@@ -246,13 +247,12 @@
         }
 
         // show the selected directory in the upload tab and set the form values accordingly
-        $(self.frameId + ' #caption1').text(selectedPath);
-        $(self.frameId + ' #caption2').text(selectedPath);
-        $(self.frameId + ' form[name="newdir"] input[name="path"]').val(selectedPath);
-        $(self.frameId + ' form[name="properties"] input[name="path"]').val(selectedPath);
+        self.$frame.find('.con_caption1').text(selectedPath);
+        self.$frame.find('.con_caption2').text(selectedPath);
+        self.$frame.find('form[name="newdir"] input[name="path"]').val(selectedPath);
+        self.$frame.find('form[name="properties"] input[name="path"]').val(selectedPath);
 
-
-        if (self.scriptLoaded == 1) {
+        if (self.scriptLoaded === 1) {
             self.imageFileUpload();
         }
     };
@@ -265,23 +265,24 @@
         var self = this;
 
         function _resetMeta() {
-            $('#image_medianame_' + self.id).val('');
-            $('#image_description_' + self.id).val('');
-            $('#image_keywords_' + self.id).val('');
-            $('#image_internal_notice_' + self.id).val('');
-            $('#image_copyright_' + self.id).val('');
+            self.getSettingElement('image_medianame').val('');
+            self.getSettingElement('image_description').val('');
+            self.getSettingElement('image_keywords').val('');
+            self.getSettingElement('image_internal_notice').val('');
+            self.getSettingElement('image_copyright').val('');
         }
 
-        if ($('#image_filename_' + self.id).length > 0) {
-            $(self.frameId + ' select[name="image_filename"]').change(function() {
-                var filename = $('select#image_filename_' + self.id + ' option:selected').val();
+        var $imageFilename = this.getSettingElement('image_filename');
+        if ($imageFilename.length > 0) {
+            $imageFilename.change(function() {
+                var filename = $imageFilename.val();
                 if (!filename) {
                     filename = '';
                 }
 
                 // update the image preview element with the new selected image
                 if (filename === '') {
-                    $('#directoryShow_' + self.id).html('');
+                    $(self.frameId + ' .con_directory_show').html('');
                 } else {
                     self.showActiveImg();
                 }
@@ -299,12 +300,12 @@
 							}
 
                             var imageMeta = $.parseJSON(msg);
-                            $('#image_medianame_' + self.id).val(imageMeta.medianame);
-                            $('#image_description_' + self.id).val(imageMeta.description);
-                            $('#image_keywords_' + self.id).val(imageMeta.keywords);
-                            $('#image_internal_notice_' + self.id).val(imageMeta.internal_notice);
-                            $('#image_copyright_' + self.id).val(imageMeta.copyright);
-                            self.showUrlforMeta();
+                            self.getSettingElement('image_medianame').val(imageMeta.medianame);
+                            self.getSettingElement('image_description').val(imageMeta.description);
+                            self.getSettingElement('image_keywords').val(imageMeta.keywords);
+                            self.getSettingElement('image_internal_notice').val(imageMeta.internal_notice);
+                            self.getSettingElement('image_copyright').val(imageMeta.copyright);
+                            self.showUrlForMeta();
                         }
                     });
                 }
@@ -319,9 +320,11 @@
      * @method createMKDir
      */
     cContentTypeImgeditor.prototype.createMKDir = function() {
-        var self = this;
-        $(self.frameId + ' #upload form[name="newdir"] input[type="image"]').unbind('click');
-        $(self.frameId + ' #upload form[name="newdir"] input[type="image"]').click(function() {
+        var self = this,
+            $uplImage = this.$frame.find('.' + this.getElementCssClass('tab_upload') + ' form[name="newdir"] input[type="image"]');
+
+        $uplImage.unbind('click');
+        $uplImage.click(function() {
             var folderName = self.getSelectedFolder();
             if (folderName === false) {
                 return false;
@@ -361,19 +364,19 @@
         }
 
         $('body > input[type=file]').remove();
-        $('#cms_image_m' + self.id).unbind();
 
+        var $fileUpload = this.$frame.find('input.jqueryAjaxUpload');
 
-        $(self.frameId + ' input.jqueryAjaxUpload').unbind();
-        $(self.frameId + ' input.jqueryAjaxUpload').fileupload({
+        $fileUpload.unbind();
+        $fileUpload.fileupload({
             url: self.pathBackend + 'ajaxmain.php?ajax=upl_upload&id=' + self.id + '&idartlang=' + self.idArtLang + '&path=' + dirname + '&contenido=' + self.session,
             dataType: 'json',
             autoUpload: true,
             forceIframeTransport: true,
             multipart: true,
             start: function(e) {
-                $(self.frameId + ' img.loading').show();
-                $(self.frameId + ' input.jqueryAjaxUpload').css('visibility', 'hidden');
+                self.$frame.find('img.loading').show();
+                $fileUpload.css('visibility', 'hidden');
             },
             always: function(e, data) {
                 if (dirname === 'upload' || dirname === '') {
@@ -388,11 +391,11 @@
 							return false;
 						}
 
-                        $(self.frameId + ' img.loading').hide();
-                        $(self.frameId + ' input.jqueryAjaxUpload').css('visibility', 'visible');
-                        $(self.frameId + ' #directoryFile_' + self.id).html(msg);
+                        self.$frame.find('img.loading').hide();
+                        $fileUpload.css('visibility', 'visible');
+                        self.$frame.find('.con_directory_file').html(msg);
                         self.addSelectAction();
-                        if (self.scriptLoaded == 1) {
+                        if (self.scriptLoaded === 1) {
                             self.imageFileUpload();
                         }
                     }
@@ -403,18 +406,18 @@
 
     /**
      * Updates the filename in the meta tab.
-     * @method showUrlforMeta
+     * @method showUrlForMeta
      */
-    cContentTypeImgeditor.prototype.showUrlforMeta = function() {
-        var filename = $(this.frameId + ' select#image_filename_' + this.id + ' option:selected').val();
-        $(this.frameId + ' #image_meta_url_' + this.id).html(filename);
+    cContentTypeImgeditor.prototype.showUrlForMeta = function() {
+        var filename = this.getSettingElement('image_filename').val();
+        this.$frame.find('.image_meta_url').html(filename);
     };
 
     /**
      * Get selected foldername
      */
     cContentTypeImgeditor.prototype.getSelectedFolder = function () {
-        var folderName = $(this.frameId + ' input[name="foldername"]').val();
+        var folderName = this.$frame.find('input[name="foldername"]').val();
         // if folder name is empty, do nothing
         if (folderName === '') {
             folderName = false;
@@ -456,9 +459,21 @@
                 }
 
                 var titles = [];
-                $(self.frameId + ' div a[class="on"]').each(function () {
+                self.$frame.find('div a[class="on"]').each(function () {
                     titles.push($(this).attr('title'));
                 });
+
+                var treeItemsFunction = function () {
+                    self.$frame.find('.con_str_tree li div>a').each(function (index) {
+                        if ($(this).attr('title') === self.selectedPath) {
+                            $(this).parent().parent('li:has(ul)').children('ul').remove();
+                            $(this).parent().after(msg);
+
+                            $(this).parent().parent('li').removeClass('collapsed');
+                            self.addNaviActions();
+                        }
+                    });
+                };
 
                 if (typeof folderName !== 'undefined') {
                     var title;
@@ -469,30 +484,14 @@
                     }
 
                     if ($.inArray(title, titles) === -1) {
-                        $(self.frameId + ' .con_str_tree li div>a').each(function (index) {
-                            if ($(this).attr('title') === self.selectedPath) {
-                                $(this).parent().parent('li:has(ul)').children('ul').remove();
-                                $(this).parent().after(msg);
-
-                                $(this).parent().parent('li').removeClass('collapsed');
-                                self.addNaviActions();
-                            }
-                        });
+                        treeItemsFunction();
                     }
                 } else {
-                    $(self.frameId + ' .con_str_tree li div>a').each(function (index) {
-                        if ($(this).attr('title') === self.selectedPath) {
-                            $(this).parent().parent('li:has(ul)').children('ul').remove();
-                            $(this).parent().after(msg);
-
-                            $(this).parent().parent('li').removeClass('collapsed');
-                            self.addNaviActions();
-                        }
-                    });
+                    treeItemsFunction();
                 }
-                //remove upload acitve, if image selected.
-                if ($(self.frameId + ' div[class="active"] a[class="on"]').length > 1) {
-                    $(self.frameId + ' li[class="root"] > div').removeClass('active');
+                //remove upload active, if image selected.
+                if (self.$frame.find('div[class="active"] a[class="on"]').length > 1) {
+                    self.$frame.find('li[class="root"] > div').removeClass('active');
                 }
                 self.showActiveFilename();
             }
@@ -506,14 +505,14 @@
     cContentTypeImgeditor.prototype.showActiveFilename = function () {
         var self = this;
         // get the selected directory
-        self.selectedPath = $(self.frameId + ' div[class="active"] a[class="on"]').attr('title');
+        self.selectedPath = this.$frame.find('div[class="active"] a[class="on"]').attr('title');
 
         var dirname = self.selectedPath;
         if (dirname === 'upload') {
             dirname = '/';
         }
 
-        $(self.frameId + ' select#image_filename_' + self.id + ' option:selected').prop('selected', false);
+        this.getSettingElement('image_filename').prop('selected', false);
 
         // update the file list each time a new directory is selected
         $.ajax({
@@ -525,10 +524,10 @@
                     return false;
                 }
 
-                $(self.frameId + ' #directoryFile_' + self.id).html(msg);
+                self.$frame.find('.con_directory_file').html(msg);
                 // the items of the file select element have been changed, so add the event handlers again
                 self.addSelectAction();
-                $(self.frameId + ' select#image_filename_' + self.id).trigger('change');
+                self.getSettingElement('image_filename').trigger('change');
                 self.showActiveImg();
             }
         });
@@ -540,7 +539,7 @@
      */
     cContentTypeImgeditor.prototype.showActiveImg = function () {
         var self = this;
-        var filename = $('select#image_filename_' + self.id + ' option:selected').val();
+        var filename = this.getSettingElement('image_filename').val();
         if (filename) {
             var url = self.pathFrontend + 'upload/' + filename;
             $.ajax({
@@ -548,7 +547,7 @@
                 url: self.pathBackend + 'ajaxmain.php',
                 data: 'ajax=scaleImage&url=' + url + '&idartlang=' + self.idArtLang + '&contenido=' + self.session,
                 success: function (msg) {
-                    $('#directoryShow_' + self.id).html('<div><img src="' + msg + '" alt=""/></div>');
+                    self.$frame.find('.con_directory_show').html('<div><img src="' + msg + '" alt=""/></div>');
                 }
             });
         }

--- a/contenido/scripts/content_types/cmsLinkeditor.js
+++ b/contenido/scripts/content_types/cmsLinkeditor.js
@@ -107,14 +107,14 @@
         this.setCurrentTab();
 
         // show the basic settings "tab" any time
-        $(this.frameId + ' .tabs #basic-settings').show();
-        $(this.frameId + ' .menu li').bind('click', function() {
-            $(self.frameId + ' .tabs #basic-settings').show();
+        this.$frame.find('.con_tab_content .con_tab_basic_settings_content').show();
+        this.$frame.find('.con_tab_menu li').bind('click', function() {
+            self.$frame.find('.con_tab_content .con_tab_basic_settings_content').show();
         });
     };
 
     /**
-     * Adds event which fades in the edit form when editbutton is clicked.
+     * Adds event which fades in the edit form when edit button is clicked.
      * @method addFrameShowEvent
      * @override
      */
@@ -140,13 +140,15 @@
      * @method setCurrentTab
      */
     cContentTypeLinkeditor.prototype.setCurrentTab = function () {
-        var linkeditorType = this.settings.linkeditor_type ? this.settings.linkeditor_type : 'external';
+        var linkeditorType = this.settings.linkeditor_type ? this.settings.linkeditor_type : 'external',
+            tabClassName = 'con_tab_' + linkeditorType,
+            tabContentClassName = 'con_tab_' + linkeditorType + '_content';
 
-        $(this.frameId + ' .tabs > div').hide();
-        $(this.frameId + ' .tabs #' + linkeditorType).show();
+        this.$frame.find('.con_tab_content > div').hide();
+        this.$frame.find('.con_tab_content .' + tabContentClassName).show();
         // set the active class for the corresponding menu entry and remove it from the others
-        $(this.frameId + ' .menu li').removeClass('active');
-        $(this.frameId + ' .menu li.' + linkeditorType).addClass('active');
+        this.$frame.find('.con_tab_menu li').removeClass('active');
+        this.$frame.find('.con_tab_menu li.' + tabClassName).addClass('active');
     }
 
     /**
@@ -158,11 +160,11 @@
         }
 
         // load internal categories and articles
-        this.getCategoriesList($(this.frameId + ' #internal #directoryList_' + this.id + ' em a').parent().parent(), '0', '0');
+        this.getCategoriesList(this.$frame.find('.con_tab_internal_content .con_directory_list em a').parent().parent(), '0', '0');
         this.getArticlesList();
 
         // load external dirs and files
-        this.getDirsList($(this.frameId + ' #file #directoryList_' + this.id + ' em a').parent().parent(), '');
+        this.getDirsList(this.$frame.find('.con_tab_file_content .con_directory_list em a').parent().parent(), '');
         this.getImagesList();
 
         this.refreshed = true;
@@ -177,9 +179,9 @@
     cContentTypeLinkeditor.prototype.addNaviActions = function() {
         var self = this;
 
-        $(this.frameId + ' #internal #directoryList_' + this.id + ' a[class="on"]').parent('div').unbind('click')
+        this.$frame.find('.con_tab_internal_content .con_directory_list a[class="on"]').parent('div').unbind('click')
             .bind('click', function() {
-                $(self.frameId + ' div').each(function() {
+                self.$frame.find('div').each(function() {
                 $(this).removeClass('active');
             });
             $(this).addClass('active');
@@ -190,7 +192,7 @@
         });
 
         // add possibility to expand and close directories for the article view
-        $(this.frameId + ' #internal #directoryList_' + this.id + ' em a').unbind('click')
+        this.$frame.find('.con_tab_internal_content .con_directory_list em a').unbind('click')
             .bind('click', function() {
             var divContainer = $(this).parent().parent();
             if (!_bindCollapsing(divContainer)) {
@@ -202,10 +204,10 @@
             return false;
         });
 
-        $(this.frameId + ' #file #directoryList_' + this.id + ' a[class="on"]').parent('div').unbind('click')
+        this.$frame.find('.con_tab_file_content .con_directory_list a[class="on"]').parent('div').unbind('click')
             .bind('click', function() {
             // update the "active" class
-            $(self.frameId + ' div').each(function() {
+            self.$frame.find('div').each(function() {
                 $(this).removeClass('active');
             });
             $(this).addClass('active');
@@ -219,7 +221,7 @@
             });
 
         // add possibility to expand and close directories for the file view
-        $(this.frameId + ' #file #directoryList_' + this.id + ' em a')
+        this.$frame.find('.con_tab_file_content .con_directory_list em a')
             .unbind('click')
             .bind('click', function () {
                 var divContainer = $(this).parent().parent();
@@ -262,7 +264,7 @@
                     return false;
                 }
 
-                $(self.frameId + ' #internal #directoryFile_' + self.id).html(msg);
+                self.$frame.find('.con_tab_internal_content #con_directory_file_' + self.id).html(msg);
             }
         });
     }
@@ -328,7 +330,7 @@
                     return false;
                 }
 
-                $(self.frameId + ' #file #directoryFile_' + self.id).html(msg);
+                self.$frame.find('.con_tab_file_content #con_directory_file_' + self.id).html(msg);
             }
         });
 
@@ -375,15 +377,15 @@
         var self = this;
         // if there are no directories, set the active class for the root upload folder
         var titles = new Array();
-        $(self.frameId + ' div[class="active"] a[class="on"]').each(function() {
+        self.$frame.find('div[class="active"] a[class="on"]').each(function() {
             titles.push($(this).attr('title'));
         });
         if (titles.length < 1) {
-            $(self.frameId + ' li.root>div').addClass('active');
+            self.$frame.find('li.root>div').addClass('active');
         }
 
         // get the selected directory and save it
-        var selectedPath = $(self.frameId + ' div[class="active"] a[class="on"]').attr('title');
+        var selectedPath = self.$frame.find('div[class="active"] a[class="on"]').attr('title');
         self.selectedPath = selectedPath;
         if (selectedPath !== '' && selectedPath !== 'upload') {
             selectedPath += '/';
@@ -391,10 +393,10 @@
             selectedPath = '';
         }
 
-        $(self.frameId + ' #caption1').text(selectedPath);
-        $(self.frameId + ' #caption2').text(selectedPath);
-        $(self.frameId + ' form[name="newdir"] input[name="path"]').val(selectedPath);
-        $(self.frameId + ' form[name="properties"] input[name="path"]').val(selectedPath);
+        self.$frame.find('.con_caption1').text(selectedPath);
+        self.$frame.find('.con_caption2').text(selectedPath);
+        self.$frame.find('form[name="newdir"] input[name="path"]').val(selectedPath);
+        self.$frame.find('form[name="properties"] input[name="path"]').val(selectedPath);
 
         self.linkEditorFileUpload();
     };
@@ -404,23 +406,22 @@
      * @method linkEditorFileUpload
      */
     cContentTypeLinkeditor.prototype.linkEditorFileUpload = function() {
-
         var self = this;
         var dirname = '';
         if (self.selectedPath !== '' && self.selectedPath !== 'upload') {
             dirname = self.selectedPath + '/';
         }
 
-        $(self.frameId + ' input.jqueryAjaxUpload').unbind();
-        $(self.frameId + ' input.jqueryAjaxUpload').fileupload({
+        self.$frame.find('input.jqueryAjaxUpload').unbind();
+        self.$frame.find('input.jqueryAjaxUpload').fileupload({
             url: self.pathBackend + 'ajaxmain.php?ajax=upl_upload&id=' + self.id + '&idartlang=' + self.idArtLang + '&path=' + dirname + '&contenido=' + self.session,
             dataType: 'json',
             autoUpload: true,
             forceIframeTransport: true,
             multipart: true,
             start: function() {
-                $(self.frameId + ' img.loading').show();
-                $(self.frameId + ' input.jqueryAjaxUpload').css('visibility', 'hidden');
+                self.$frame.find('img.loading').show();
+                self.$frame.find('input.jqueryAjaxUpload').css('visibility', 'hidden');
             },
             always: function() {
                 if (dirname === 'upload' || dirname === '') {
@@ -436,9 +437,9 @@
 							return false;
 						}
 
-                        $(self.frameId + ' img.loading').hide();
-                        $(self.frameId + ' input.jqueryAjaxUpload').css('visibility', 'visible');
-                        $(self.frameId + ' #file #directoryFile_' + self.id).html(msg);
+                        self.$frame.find('img.loading').hide();
+                        self.$frame.find('input.jqueryAjaxUpload').css('visibility', 'visible');
+                        self.$frame.find('.con_tab_file_content #con_directory_file_' + self.id).html(msg);
                     }
                 });
             }
@@ -451,9 +452,9 @@
      */
     cContentTypeLinkeditor.prototype.createMKDir = function() {
         var self = this;
-        $(self.frameId + ' #file form[name="newdir"] input[type="image"]').unbind('click');
-        $(self.frameId + ' #file form[name="newdir"] input[type="image"]').click(function() {
-            var folderName = $(self.frameId + ' input[name="foldername"]').val();
+        self.$frame.find('.con_tab_file_content form[name="newdir"] input[type="image"]').unbind('click');
+        self.$frame.find('.con_tab_file_content form[name="newdir"] input[type="image"]').click(function() {
+            var folderName = self.$frame.find('input[name="foldername"]').val();
             // if folder name is empty, do nothing
             if (folderName === '') {
                 return false;
@@ -496,7 +497,7 @@
                                     title = dirname + folderName;
                                 }
                                 var titles = [];
-                                $(self.frameId + ' div a[class="on"]').each(function() {
+                                self.$frame.find('div a[class="on"]').each(function() {
                                     titles.push($(this).attr('title'));
                                 });
 
@@ -528,10 +529,10 @@
      */
     cContentTypeLinkeditor.prototype.addSaveEvent = function() {
         var self = this;
-        $(self.frameId + ' .save_settings').click(function() {
+        self.$frame.find('.save_settings').click(function() {
             // the link type is no form field, so add it to the editform manually
             var type = '';
-            $(self.frameId + ' .menu li').each(function() {
+            self.$frame.find('.con_tab_menu li').each(function() {
                 // if this is the active tab, extract the tab name
                 if ($(this).hasClass('active')) {
                     var cssClass = $(this).attr('class');

--- a/contenido/scripts/content_types/cmsTeaser.js
+++ b/contenido/scripts/content_types/cmsTeaser.js
@@ -41,6 +41,41 @@
     function cContentTypeTeaser(frameId, imageId, pathBackend, pathFrontend, idArtLang, id, fields, prefix, session, settings) {
         // call the constructor of the parent class with the same arguments
         Con.cContentTypeAbstractTabbed.apply(this, arguments);
+
+        /**
+         * Reference to category select.
+         * @property $categorySelect
+         * @type {HTMLElement[]}
+         */
+        this.$categorySelect = this.getSettingElement('teaser_cat');
+
+        /**
+         * Reference to article select.
+         * @property $articleSelect
+         * @type {HTMLElement[]}
+         */
+        this.$articleSelect = this.getSettingElement('teaser_art');
+
+        /**
+         * Reference to manual article select.
+         * @property $manualArtSelect
+         * @type {HTMLElement[]}
+         */
+        this.$manualArtSelect = this.getSettingElement('teaser_manual_art');
+
+        /**
+         * Reference to add article button.
+         * @property $addArtButton
+         * @type {HTMLElement[]}
+         */
+        this.$addArtButton = this.$frame.find('#' + this.getElementId('add_art'));
+
+        /**
+         * Reference to delete article button.
+         * @property $delArtButton
+         * @type {HTMLElement[]}
+         */
+        this.$delArtButton = this.$frame.find('#' + this.getElementId('del_art'));
     }
 
     // inherit from cContentTypeAbstractTabbed
@@ -87,7 +122,7 @@
      */
     cContentTypeTeaser.prototype.getArticleList = function() {
         var self = this;
-        $(self.frameId + ' #teaser_cat_' + self.id).change(function() {
+        $(this.$categorySelect).change(function() {
             // get new article select and replace it with default value
             $.ajax({
                 type: 'POST',
@@ -98,7 +133,8 @@
 						return false;
 					}
 
-                    $(self.frameId + ' #teaser_art_' + self.id).replaceWith(msg);
+                    self.$articleSelect.replaceWith(msg);
+                    self.$articleSelect = self.getSettingElement('teaser_art_' + self.id);
                 }
             });
         });
@@ -111,8 +147,8 @@
      */
     cContentTypeTeaser.prototype.addManualTeaser = function() {
         var self = this;
-        $(self.frameId + ' #add_art_' + self.id).css('cursor', 'pointer');
-        $(self.frameId + ' #add_art_' + self.id).click(function() {
+        this.$addArtButton.css('cursor', 'pointer');
+        this.$addArtButton.click(function() {
             // call internal add function
             self.addManualTeaserEntry();
         });
@@ -124,29 +160,19 @@
      * @method addManualTeaserEntry
      */
     cContentTypeTeaser.prototype.addManualTeaserEntry = function() {
-        var idArt = $(this.frameId + ' #teaser_art_' + this.id).val();
+        var idArt = parseInt(this.$articleSelect.val());
         var name = '';
         var exists = false;
 
         // if an article was selected
         if (idArt > 0) {
             // check if article already exists in view list
-            $(this.frameId + ' #teaser_manual_art_' + this.id + ' option').each(function() {
-                if (idArt == $(this).val()) {
-                    exists = true;
-                }
-            });
-
-            // get name of selected article
-            $(this.frameId + ' #teaser_art_' + this.id + ' option').each(function() {
-                if (idArt == $(this).val()) {
-                    name = $(this).html();
-                }
-            });
+            exists = this.$manualArtSelect.find('option[value="' + idArt + '"]').length > 0;
 
             // if it is not in list, add article to list
             if (!exists) {
-                $(this.frameId + ' #teaser_manual_art_' + this.id).append('<option value="' + idArt + '" selected="selected">' + name + '</option>');
+                name = this.$articleSelect.find('option[value="' + idArt + '"]').text();
+                this.$manualArtSelect.append('<option value="' + idArt + '" selected="selected">' + name + '</option>');
             }
         }
     };
@@ -158,14 +184,14 @@
      */
     cContentTypeTeaser.prototype.removeManualTeaser = function() {
         var self = this;
-        $(self.frameId + ' #teaser_manual_art_' + self.id).dblclick(function() {
-            $(self.frameId + ' #teaser_manual_art_' + self.id + ' option:selected').each(function() {
+        this.$manualArtSelect.dblclick(function() {
+            self.$manualArtSelect.find('option:selected').each(function() {
                 $(this).remove();
             });
         });
 
-        $(self.frameId + ' #del_art_' + self.id).on('click', function() {
-            $(self.frameId + ' #teaser_manual_art_' + self.id + ' option').remove();
+        this.$delArtButton.on('click', function() {
+            self.$manualArtSelect.find('option').remove();
         });
     };
 

--- a/contenido/styles/content_types/cms_abstract_tabbed.css
+++ b/contenido/styles/content_types/cms_abstract_tabbed.css
@@ -40,7 +40,7 @@
     margin-top: 5px;
 }
 
-.cms_abstract .tabs {
+.cms_abstract .con_tab_content {
     padding-top: 10px;
 }
 
@@ -93,7 +93,7 @@
     margin: 5px 6px 5px 0;
 }
 
-.cms_abstract .menu {
+.cms_abstract .con_tab_menu {
     clear: both;
     list-style-type: none;
     margin: 10px 0 0;
@@ -101,7 +101,7 @@
     height: 22px;
 }
 
-.cms_abstract .menu li {
+.cms_abstract .con_tab_menu li {
     border: 1px solid #B3B3B3;
     cursor: pointer;
     line-height: 20px;
@@ -112,9 +112,9 @@
     margin-right: 4px;
 }
 
-.cms_abstract .menu li.active {
+.cms_abstract .con_tab_menu li.active {
     font-weight: bold;
-    border-bottom: 1px solid #F1F1F1;
+    border-bottom: 2px solid #F1F1F1;
 }
 
 .cms_abstract .checkbox_wrapper {

--- a/contenido/styles/content_types/cms_dirlist.css
+++ b/contenido/styles/content_types/cms_dirlist.css
@@ -89,26 +89,26 @@
     background-color: #f8fddc;
 }
 
-.directoryList {
+.con_directory_list {
     background-color: #fff;
     border: 1px solid #ccc;
     height: 170px;
     margin-bottom: 10px;
     overflow: auto;
 }
-.directoryList .con_str_tree {
+.con_directory_list .con_str_tree {
     margin: 0;
 }
-.directoryList li.root > div > em {
+.con_directory_list li.root > div > em {
     background: url("../../images/ordner_oben.gif") no-repeat 0 2px;
     font-style: italic;
     height: 20px;
     padding: 0;
 }
-.directoryList li.root > div > em a {
+.con_directory_list li.root > div > em a {
     display: none;
 }
-.directoryList li.root > div > a {
+.con_directory_list li.root > div > a {
     background: none;
     padding: 0;
 }

--- a/contenido/styles/content_types/cms_filelist.css
+++ b/contenido/styles/content_types/cms_filelist.css
@@ -15,23 +15,23 @@
     width: 432px;
 }
 
-.cms_filelist .directoryList {
+.cms_filelist .con_directory_list {
     height: 205px;
     width: 410px;
 }
 
-.cms_filelist #manual .directoryList {
+.cms_filelist .con_tab_manual_content .con_directory_list {
     height: 135px;
 }
 
-.cms_filelist #manual_filelist_setting {
+.cms_filelist .filelist_manual_filelist_setting {
     clear: both;
 }
 
 .cms_filelist label {
     width: 220px;
 }
-.cms_filelist label.filelist_filename {
+.cms_filelist label.filelist_filename_label {
     width: 100px;
 }
 
@@ -39,7 +39,7 @@
     width: 300px;
 }
 
-.cms_filelist #add_file {
+.cms_filelist .filelist_add_file {
     margin: 2px 0 0 5px;
 }
 
@@ -50,43 +50,43 @@
     float: left;
 }
 
-.cms_filelist #metaDataList {
+.cms_filelist .filelist_meta_data_list {
     clear: both;
 }
 
-.cms_filelist #metaDataList  ul li {
+.cms_filelist .filelist_meta_data_list  ul li {
     list-style: none;
 }
 
-.cms_filelist #metaDataList input {
+.cms_filelist .filelist_meta_data_list input {
     width: 30px;
 }
 
-#filter span,
-#metaDataList span,
-#manual span {
+.con_tab_filter_content span,
+.filelist_meta_data_list span,
+.con_tab_manual_content span {
     float: left;
 }
 
-.cms_filelist #filter .manual {
+.cms_filelist .con_tab_filter_content .manual {
     width: 420px;
 }
 
-.cms_filelist #filter input {
+.cms_filelist .con_tab_filter_content input {
     font-size: 10px;
     width: 75px;
 }
 
-.cms_filelist #filter #filelist_all_extensions {
+.cms_filelist .con_tab_filter_content .filelist_all_extensions {
     display: block;
     margin: 5px 0;
 }
 
-.cms_filelist #filter label.filelist_ignore_extensions {
+.cms_filelist .con_tab_filter_content label.filelist_ignore_extensions {
     margin: 5px 0;
     width: 230px;
 }
 
-.cms_filelist #manual .manual {
+.cms_filelist .con_tab_manual_content .manual {
     width: 420px;
 }

--- a/contenido/styles/content_types/cms_imgeditor.css
+++ b/contenido/styles/content_types/cms_imgeditor.css
@@ -1,12 +1,12 @@
 @import url("cms_dirlist.css");
 
-.cms_imgeditor .directoryList {
+.cms_imgeditor .con_directory_list {
     float: left;
     margin-right: 1.5%;
     width: 48%;
 }
 
-.cms_imgeditor .directoryShow {
+.cms_imgeditor .con_directory_show {
     width: 99%;
 }
 
@@ -14,7 +14,7 @@
     width: 430px;
 }
 
-.cms_imgeditor .directoryFile {
+.cms_imgeditor .con_directory_file {
     background-color: #ffffff;
     border: 1px solid #CCC;
     height: 170px;
@@ -22,8 +22,8 @@
     width: 49%;
 }
 
-.cms_imgeditor .directories .directoryShow,
-.cms_imgeditor .upload .directoryShow
+.cms_imgeditor .con_tab_directories_content .con_directory_show,
+.cms_imgeditor .con_tab_upload_content .con_directory_show
     {
     background-color: #FFFFFF;
     border: 1px solid #CCCCCC;
@@ -35,11 +35,15 @@
 .cms_imgeditor b {
     display: block;
 }
-.cms_imgeditor .meta label {
+.cms_imgeditor .con_tab_meta_content label {
    /* margin: 10px 0 3px 10px;*/
 }
 
-.cms_imgeditor .meta input {
+.cms_imgeditor .con_tab_meta_content .con_selected_file {
+    margin-bottom: 5px;
+}
+
+.cms_imgeditor .con_tab_meta_content input {
     border: 1px solid #ccc;
     font-size: 11px;
     margin-bottom: 5px;
@@ -47,7 +51,7 @@
     margin-top: 2px;
 }
 
-.cms_imgeditor .meta textarea {
+.cms_imgeditor .con_tab_meta_content textarea {
     border: 1px solid #ccc;
     font-size: 11px;
     height: 50px;
@@ -82,8 +86,7 @@
     position: absolute;
 }
 
-.cms_imgeditor #caption1,
-.cms_imgeditor #caption2,
+.cms_imgeditor .con_caption,
 .cms_imgeditor .image_meta_url {
     margin-left: 10px;
 }

--- a/contenido/styles/content_types/cms_linkeditor.css
+++ b/contenido/styles/content_types/cms_linkeditor.css
@@ -1,6 +1,6 @@
 @import url("cms_dirlist.css");
 
-.cms_linkeditor .directoryList {
+.cms_linkeditor .con_directory_list {
     float: left;
     margin-right: 5px;
     width: 210px;
@@ -10,7 +10,7 @@
     width: 550px;
 }
 
-.cms_linkeditor .directoryFile {
+.cms_linkeditor .con_directory_file {
     border: 1px solid #CCC;
     height: 170px;
     overflow: visible;
@@ -24,7 +24,7 @@
     width: 330px;
 }
 
-.cms_linkeditor #basic-settings {
+.cms_linkeditor .con_tab_basic_settings_content {
     margin-top: 15px;
 }
 
@@ -41,7 +41,7 @@
     top: 25%;
 }
 
-.cms_linkeditor #caption1,.cms_linkeditor #caption2 {
+.cms_linkeditor .con_caption {
     margin-left: 10px;
 }
 

--- a/contenido/templates/standard/template.cms_abstract_tabbed_edit_bottom.html
+++ b/contenido/templates/standard/template.cms_abstract_tabbed_edit_bottom.html
@@ -3,34 +3,36 @@
 </div>
 
 <script type="text/javascript">
-    var initCallBack = function() {
-        var contentTypeInstance = new {JS_CLASS_NAME}(
-            '#cms_{PREFIX}_{ID}_settings',
-            '#cms_{PREFIX}_{ID}',
-            Con.cfg.urlBackend,
-            '{PATH_FRONTEND}',
-            '{IDARTLANG}',
-            '{ID}',
-            Array({FIELDS}),
-            '{PREFIX}',
-            Con.sid,
-            {SETTINGS}
-        );
-        setTimeout(function () {
-            contentTypeInstance.initialise();
-        }, 0);
-    };
+    (function () {
+        var initCallBack = function () {
+            var contentTypeInstance = new {JS_CLASS_NAME}(
+                '#cms_{PREFIX}_{ID}_settings',
+                '#cms_{PREFIX}_{ID}',
+                Con.cfg.urlBackend,
+                '{PATH_FRONTEND}',
+                '{IDARTLANG}',
+                '{ID}',
+                [{FIELDS}],
+                '{PREFIX}',
+                Con.sid,
+                {SETTINGS}
+            );
+            setTimeout(function () {
+                contentTypeInstance.initialise();
+            }, 0);
+        };
 
-    if (typeof {JS_CLASS_NAME} === 'undefined' || typeof Con.cContentTypeAbstractTabbed === 'undefined') {
-        Con.Loader.get(
-            [
-                Con.cfg.urlBackend + 'scripts/content_types/cmsAbstractTabbed.js',
-                '{JS_CLASS_SCRIPT}'
-            ],
-            initCallBack
-        );
-    } else {
-        initCallBack();
-    }
+        if (typeof {JS_CLASS_NAME} === 'undefined' || typeof Con.cContentTypeAbstractTabbed === 'undefined') {
+            Con.Loader.get(
+                [
+                    Con.cfg.urlBackend + 'scripts/content_types/cmsAbstractTabbed.js',
+                    '{JS_CLASS_SCRIPT}'
+                ],
+                initCallBack
+            );
+        } else {
+            initCallBack();
+        }
+    })();
 </script>
 <!-- /template.cms_abstract_tabbed_edit_bottom.html -->

--- a/contenido/templates/standard/template.cms_abstract_tabbed_edit_tab_menu.html
+++ b/contenido/templates/standard/template.cms_abstract_tabbed_edit_tab_menu.html
@@ -1,7 +1,5 @@
-<div class="clearfix">
-    <ul class="menu">
-        <!-- BEGIN:BLOCK -->
-        <li class="{TAB_ID}">{TAB_NAME}</li>
-        <!-- END:BLOCK -->
-    </ul>
-</div>
+<ul class="con_tab_menu clearfix">
+    <!-- BEGIN:BLOCK -->
+    <li class="con_tab_item {TAB_ID}" data-tab-content="{TAB_ID}_content">{TAB_NAME}</li>
+    <!-- END:BLOCK -->
+</ul>

--- a/contenido/templates/standard/template.cms_abstract_tabbed_edit_tabs.html
+++ b/contenido/templates/standard/template.cms_abstract_tabbed_edit_tabs.html
@@ -1,6 +1,6 @@
-<div id="{PREFIX}_tabs" class="tabs">
+<div class="con_tab_content">
     <!-- BEGIN:BLOCK -->
-    <div id="{TAB_ID}" class="{TAB_CLASS}">
+    <div class="{TAB_CLASS}">
         {TAB_CONTENT}
     </div>
     <!-- END:BLOCK -->

--- a/contenido/templates/standard/template.cms_abstract_tabbed_edit_top.html
+++ b/contenido/templates/standard/template.cms_abstract_tabbed_edit_top.html
@@ -1,8 +1,8 @@
 <span class="con_content_type_controls">
-    <img id="cms_{PREFIX}_{ID}" class="con_img_button cms_abstract_img cms_{PREFIX}_img" alt="" src="{_PATH_CONTENIDO_FULLHTML_}{ICON}">
+    <img id="{CONTENT_TYPE_ID}" class="con_img_button cms_abstract_img cms_{PREFIX}_img" alt="" src="{_PATH_CONTENIDO_FULLHTML_}{ICON}">
 </span>
-<div style="display:none;" id="cms_{PREFIX}_{ID}_settings" class="con_content_type_settings cms_abstract cms_{PREFIX}">
-    <div class="close" id="{PREFIX}_close">
+<div style="display:none;" id="{CONTENT_TYPE_ID}_settings" class="con_content_type_settings cms_abstract cms_{PREFIX}">
+    <div class="close">
         <img src="{_PATH_CONTENIDO_FULLHTML_}images/but_cancel.gif" alt="">
     </div>
     <p class="head">{HEADLINE}</p>

--- a/contenido/templates/standard/template.cms_date.html
+++ b/contenido/templates/standard/template.cms_date.html
@@ -1,5 +1,9 @@
 <script type="text/javascript">
-Con.Loader.get([Con.cfg.urlBackend + 'scripts/content_types/cmsDate.js'], function() {
+Con.Loader.get(
+    [
+        Con.cfg.urlBackend + 'scripts/base64.js',
+        Con.cfg.urlBackend + 'scripts/content_types/cmsDate.js'
+    ], function() {
     var contentTypeInstance = new Con.cContentTypeDate(
         '#cms_{PREFIX}_{ID}_settings',
         '{PREFIX}',

--- a/contenido/templates/standard/template.cms_filelist_edit.html
+++ b/contenido/templates/standard/template.cms_filelist_edit.html
@@ -1,3 +1,4 @@
+<!-- TODO Is this still in use somewhere? -->
 <img id="cms_filelist_{ID}" alt="" class="cms_filelist_img cms_filelist_{ID}_EDIT CMS_LINK_EDIT" src="{_PATH_CONTENIDO_FULLHTML_}images/but_downloadlist.gif">
 <div style="display:none" id="cms_filelist_{ID}_settings" class="cms_filelist">
     <div class="close" id="filelist_close">
@@ -5,17 +6,17 @@
     </div>
     <p class="head">{LABEL_FILELIST_SETTINGS}</p>
 
-    <ul class="menu">
-        <li class="directories">{DIRECTORIES}</li>
-        <li class="general">{GENERAL}</li>
-        <li class="filter">{FILTER}</li>
-        <li class="manual">{MANUAL}</li>
+    <ul class="con_tab_menu clearfix">
+        <li class="con_tab_item con_tab_directories" data-tab-content="con_tab_directories_content">{DIRECTORIES}</li>
+        <li class="con_tab_item con_tab_general" data-tab-content="con_tab_general_content">{GENERAL}</li>
+        <li class="con_tab_item con_tab_filter" data-tab-content="con_tab_filter_content">{FILTER}</li>
+        <li class="con_tab_item con_tab_manual" data-tab-content="con_tab_manual_content">{MANUAL}</li>
     </ul>
-    <div id="tabs">
+    <div class="con_tab_content">
         <div class="directories">
             <p class="head_sub">{LABEL_SOURCE_DIRECTORY}</p>
 
-            <div class="directoryList">
+            <div class="con_directory_list">
                 <ul class="con_str_tree" dir="ltr">
                     <li class="root last">
                         <em>Uploads</em>
@@ -24,7 +25,7 @@
                 </ul>
             </div>
         </div>
-        <div id="general">
+        <div class="con_tab_general_content">
             <p class="head_sub">{LABEL_GENERAL}</p>
 
             <label for="filelist_title">{LABEL_FILELIST_TITLE}:</label>
@@ -51,7 +52,7 @@
 
             <div class="head_sub head_sep">&nbsp;</div>
         </div>
-        <div id="filter">
+        <div class="con_tab_filter_content">
             <p class="head_sub">{LABEL_FILTER}</p>
 
             <label for="filelist_extensions">{LABEL_FILE_EXTENSIONS}:</label>
@@ -80,7 +81,7 @@
 
             <div class="head_sub head_sep">&nbsp;</div>
         </div>
-        <div id="manual">
+        <div class="con_tab_manual_content">
             <p class="head_sub">{LABEL_MANUAL}</p>
 
             <label for="filelist_manual">{LABEL_MANUAL_FILELIST}</label>
@@ -92,7 +93,7 @@
 
                 <div class="head_sub head_sep">{LABEL_ADD_FILE}</div>
                 <label for="teaser_cat">{LABEL_DIRECTORY}:</label>
-                <div class="directoryList">
+                <div class="con_directory_list">
                     <ul class="con_str_tree" dir="ltr">
                         <li class="root last">
                             <em>Uploads</em>
@@ -123,7 +124,6 @@
     var sLabelIgnoreExtensionsOn = '{LABEL_SELECTIONWILLBEIGNORED}';
     var sLabelIgnoreExtensionsOff = '{LABEL_IGNORESELECTION}';
     var bIgnoreExtensions{ID} = '{IGNOREEXTENSIONS}';
-
 
     Con.Loader.get([Con.cfg.urlBackend + 'scripts/cmsFilelist.js'], function() {
         addFileListEvents(fileListFrame{ID}, fileListImage{ID}, sPath, Con.sid, iIdArtLang, {ID}, aFileListData{ID}, bIgnoreExtensions{ID});

--- a/contenido/templates/standard/template.cms_filelist_metadata_limititem.html
+++ b/contenido/templates/standard/template.cms_filelist_metadata_limititem.html
@@ -1,7 +1,7 @@
 <ul>
 <!-- BEGIN:BLOCK -->
     <li>
-        <label for="filelist_md_{METADATA_NAME}_limit">{METADATA_DISPLAYNAME}:</label>
+        <label for="filelist_md_{METADATA_NAME}_limit_{ID}">{METADATA_DISPLAYNAME}:</label>
         <span>begrenzen auf&nbsp;</span><input name="filelist_md_{METADATA_NAME}_limit_{ID}" id="filelist_md_{METADATA_NAME}_limit_{ID}" value="{METADATA_LIMIT}"><span>&nbsp;Zeichen</span>
     </li>
 <!-- END:BLOCK -->


### PR DESCRIPTION
- Reworked files of cms types in order to use unique identifier or skip not necessary identifier.
- Moved Base64 utility from cmsDate.js to a separate file.
- Added new parameter to function `buildArticleSelect()`.
- Added new parameter to function `buildCategorySelect()`.