### PR TITLE
task: #527 Deprecated callable in Swift Mailer library #527.

### DIFF
--- a/contenido/classes/swiftmailer/lib/classes/Swift/EmbeddedFile.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/EmbeddedFile.php
@@ -26,11 +26,9 @@ class Swift_EmbeddedFile extends Swift_Mime_EmbeddedFile
      */
     public function __construct($data = null, $filename = null, $contentType = null)
     {
-        call_user_func_array(
-            array($this, 'Swift_Mime_EmbeddedFile::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('mime.embeddedfile')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('mime.embeddedfile')
+        );
 
         $this->setBody($data);
         $this->setFilename($filename);

--- a/contenido/classes/swiftmailer/lib/classes/Swift/FailoverTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/FailoverTransport.php
@@ -22,11 +22,9 @@ class Swift_FailoverTransport extends Swift_Transport_FailoverTransport
      */
     public function __construct($transports = array())
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_FailoverTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.failover')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.failover')
+        );
 
         $this->setTransports($transports);
     }

--- a/contenido/classes/swiftmailer/lib/classes/Swift/LoadBalancedTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/LoadBalancedTransport.php
@@ -22,11 +22,9 @@ class Swift_LoadBalancedTransport extends Swift_Transport_LoadBalancedTransport
      */
     public function __construct($transports = array())
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_LoadBalancedTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.loadbalanced')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.loadbalanced')
+        );
 
         $this->setTransports($transports);
     }

--- a/contenido/classes/swiftmailer/lib/classes/Swift/MimePart.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/MimePart.php
@@ -26,11 +26,9 @@ class Swift_MimePart extends Swift_Mime_MimePart
      */
     public function __construct($body = null, $contentType = null, $charset = null)
     {
-        call_user_func_array(
-            array($this, 'Swift_Mime_MimePart::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('mime.part')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('mime.part')
+        );
 
         if (!isset($charset)) {
             $charset = Swift_DependencyContainer::getInstance()

--- a/contenido/classes/swiftmailer/lib/classes/Swift/NullTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/NullTransport.php
@@ -17,10 +17,8 @@ class Swift_NullTransport extends Swift_Transport_NullTransport
 {
     public function __construct()
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_NullTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.null')
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.null')
         );
     }
 

--- a/contenido/classes/swiftmailer/lib/classes/Swift/SendmailTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/SendmailTransport.php
@@ -22,11 +22,9 @@ class Swift_SendmailTransport extends Swift_Transport_SendmailTransport
      */
     public function __construct($command = '/usr/sbin/sendmail -bs')
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_SendmailTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.sendmail')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.sendmail')
+        );
 
         $this->setCommand($command);
     }

--- a/contenido/classes/swiftmailer/lib/classes/Swift/SpoolTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/SpoolTransport.php
@@ -27,10 +27,7 @@ class Swift_SpoolTransport extends Swift_Transport_SpoolTransport
 
         $arguments[] = $spool;
 
-        call_user_func_array(
-            array($this, 'Swift_Transport_SpoolTransport::__construct'),
-            $arguments
-        );
+        parent::__construct(...$arguments);
     }
 
     /**


### PR DESCRIPTION
Replaced `call_user_func_array()` calls in Swift Mailer sources to prevent 'Deprecated: Callables of the form...' warnings.