### PR TITLE
task: #527 Deprecated callable in Swift Mailer library #527.

### DIFF
--- a/contenido/classes/swiftmailer/lib/classes/Swift/Attachment.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/Attachment.php
@@ -26,11 +26,9 @@ class Swift_Attachment extends Swift_Mime_Attachment
      */
     public function __construct($data = null, $filename = null, $contentType = null)
     {
-        call_user_func_array(
-            array($this, 'Swift_Mime_Attachment::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('mime.attachment')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('mime.attachment')
+        );
 
         $this->setBody($data);
         $this->setFilename($filename);

--- a/contenido/classes/swiftmailer/lib/classes/Swift/MailTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/MailTransport.php
@@ -24,11 +24,9 @@ class Swift_MailTransport extends Swift_Transport_MailTransport
      */
     public function __construct($extraParams = '-f%s')
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_MailTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.mail')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.mail')
+        );
 
         $this->setExtraParams($extraParams);
     }

--- a/contenido/classes/swiftmailer/lib/classes/Swift/Message.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/Message.php
@@ -42,11 +42,9 @@ class Swift_Message extends Swift_Mime_SimpleMessage
      */
     public function __construct($subject = null, $body = null, $contentType = null, $charset = null)
     {
-        call_user_func_array(
-            array($this, 'Swift_Mime_SimpleMessage::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('mime.message')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('mime.message')
+        );
 
         if (!isset($charset)) {
             $charset = Swift_DependencyContainer::getInstance()

--- a/contenido/classes/swiftmailer/lib/classes/Swift/SmtpTransport.php
+++ b/contenido/classes/swiftmailer/lib/classes/Swift/SmtpTransport.php
@@ -31,11 +31,9 @@ class Swift_SmtpTransport extends Swift_Transport_EsmtpTransport
      */
     public function __construct($host = 'localhost', $port = 25, $security = null)
     {
-        call_user_func_array(
-            array($this, 'Swift_Transport_EsmtpTransport::__construct'),
-            Swift_DependencyContainer::getInstance()
-                ->createDependenciesFor('transport.smtp')
-            );
+        parent::__construct(
+            ...Swift_DependencyContainer::getInstance()->createDependenciesFor('transport.smtp')
+        );
 
         $this->setHost($host);
         $this->setPort($port);


### PR DESCRIPTION
Replaced `call_user_func_array()` calls in Swift Mailer sources to prevent 'Deprecated: Callables of the form...' warnings.