### PR TITLE
fix: [#578] Core: cContentTypeImgeditor - Saving metadata fails

### DIFF
--- a/contenido/classes/content_types/class.content.type.imgeditor.php
+++ b/contenido/classes/content_types/class.content.type.imgeditor.php
@@ -359,7 +359,7 @@ class cContentTypeImgeditor extends cContentTypeAbstractTabbed
      */
     protected function _updateUploadMeta()
     {
-        if (!$this->_upload instanceof cApiUpload || $this->_upload->isLoaded()) {
+        if (!$this->_upload instanceof cApiUpload || !$this->_upload->isLoaded()) {
             return;
         }
 


### PR DESCRIPTION
Fix the `isLoaded()` check.