### PR TITLE
fix: [##589] cHTML: Set content with various types

### DIFF
--- a/contenido/classes/html/class.html.php
+++ b/contenido/classes/html/class.html.php
@@ -551,6 +551,8 @@ class cHTML
             if (count($content->_requiredScripts) > 0) {
                 $this->_requiredScripts = array_merge($this->_requiredScripts, $content->_requiredScripts);
             }
+        } elseif (is_int($content) || is_float($content) || is_bool($content)) {
+            $this->_content = $content;
         } else {
             // Content is tring or NULL
             $this->_content = is_string($content) ? $content : '';


### PR DESCRIPTION
Set also a content of type `int`, `float`, and `bool`.