### PR TITLE
fix: [#595] Backend: Copy template pre-configuration fails

### DIFF
--- a/contenido/classes/contenido/class.templateconfig.php
+++ b/contenido/classes/contenido/class.templateconfig.php
@@ -108,7 +108,7 @@ class cApiTemplateConfigurationCollection extends ItemCollection
         if (($template = $templateColl->next()) !== false) {
             if ($template->get('idtplcfg') > 0) {
                 $containerConfColl = new cApiContainerConfigurationCollection(sprintf(
-                    '`idtplconf` = %d',
+                    '`idtplcfg` = %d',
                     $template->get('idtplcfg')
                 ));
                 $standardConfig = [];

--- a/contenido/classes/genericdb/class.item.collection.php
+++ b/contenido/classes/genericdb/class.item.collection.php
@@ -841,13 +841,17 @@ abstract class ItemCollection extends cItemBaseAbstract
     {
         unset($this->objects);
 
-        $where = empty($where) ? '' : 'WHERE ' . $where;
-        $groupBy = empty($groupBy) ? '' : ' GROUP BY ' . $groupBy;
-        $orderBy = empty($orderBy) ? '' : ' ORDER BY ' . $orderBy;
-        $limit = empty($limit) ? '' : ' LIMIT ' . $limit;
+        $sqlParts = array_filter([
+            'SELECT',
+            $this->_settings['select_all_mode'] ? '*' : sprintf('`%s`', $this->getPrimaryKeyName()),
+            sprintf('FROM `%s`', $this->table),
+            empty($where) ? '' : sprintf('WHERE %s', $where),
+            empty($groupBy) ? '' : sprintf('GROUP BY %s', $groupBy),
+            empty($orderBy) ? '' : sprintf('ORDER BY %s', $orderBy),
+            empty($limit) ? '' : sprintf('LIMIT %s', $limit),
+        ]);
 
-        $fields = $this->_settings['select_all_mode'] ? '*' : $this->getPrimaryKeyName();
-        $sql = 'SELECT ' . $fields . ' FROM `' . $this->table . '`' . $where . $groupBy . $orderBy . $limit;
+        $sql = implode(' ', $sqlParts);
         $this->db->query($sql);
         $this->_lastSQL = $sql;
         $this->_bAllMode = $this->_settings['select_all_mode'];

--- a/contenido/includes/include.con_art_overview.php
+++ b/contenido/includes/include.con_art_overview.php
@@ -731,7 +731,7 @@ if (is_numeric($idcat) && ($idcat >= 0)) {
                         if ($tmp_sync != '') {
                             $link = new cHTMLLink(
                                 $sess->url("main.php?area=con_editart&action=con_edit&frame=4&idcat=$idcat&idart=$idart"),
-                                'aa' . cHTMLImage::img($cfg['path']['images'] . 'but_art_conf2.gif', $lngDisplayProperties),
+                                cHTMLImage::img($cfg['path']['images'] . 'but_art_conf2.gif', $lngDisplayProperties),
                                 'con_img_button mgl3'
                             );
                             $link->setAttribute('title', $lngDisplayProperties);


### PR DESCRIPTION
- Fix invalid field name in `cApiTemplateConfigurationCollection:: copyTemplatePreconfiguration()`.
- More readable query build in `ItemCollection::select()`.
- Remove some leftover debug characters in include.con_art_overview.php.