### PR TITLE
fix: [#606] Backend: Category overview error when no category exists

### DIFF
--- a/contenido/includes/include.str_overview.php
+++ b/contenido/includes/include.str_overview.php
@@ -1053,7 +1053,7 @@ $additionalPageEnd = [];
  */
 $cecIterator = cApiCecRegistry::getInstance()->getIterator('Contenido.CategoryList.PageEnd');
 while ($chainEntry = $cecIterator->next()) {
-    $additionalPageEnd[] = $chainEntry->execute($value->getId(), $cKey);
+    $additionalPageEnd[] = $chainEntry->execute();
 }
 $tpl->set('s', 'ADDITIONAL_PAGE_END', implode("\n", $additionalPageEnd));
 


### PR DESCRIPTION
Call CEC function without parameters.